### PR TITLE
feat: community discord footer link and /discord route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -78,6 +78,7 @@ import WebsitesDirectory from './pages/services/websites'
 import SitemapPage from './pages/sitemap'
 import Ideas from './pages/Ideas'
 import ScrollToTop from './components/ui/ScrollToTop'
+import Discord from './pages/Discord'
 
 function App() {
   return (
@@ -96,6 +97,7 @@ function App() {
             <Route path="/search" element={<SearchPage />} />
             <Route path="/ideas" element={<Ideas />} />
             <Route path="/sitemap" element={<SitemapPage />} />
+            <Route path="/discord" Component={Discord} />
             <Route path="/philippines/about" element={<AboutPhilippines />} />
             <Route
               path="/philippines/history"

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -79,6 +79,7 @@ export const footerNavigation = {
         // { label: 'Terms of Use', href: '/terms' },
         { label: 'Accessibility', href: '/accessibility' },
         { label: 'Contact Us', href: '/about' },
+        { label: "Community Discord", href: "/discord" },
       ],
     },
     {

--- a/src/pages/Discord.tsx
+++ b/src/pages/Discord.tsx
@@ -1,0 +1,8 @@
+import { useEffect } from "react";
+
+export default function Discord() {
+  useEffect(function () {
+    window.location.assign("https://discord.gg/5xBQmjWm");
+  }, []);
+  return <h1>Redirecting to BetterGov.ph Discord Invite Link...</h1>;
+}


### PR DESCRIPTION
This PR introduces a "Community Discord" Link within the site's footer. It also adds a new route `/discord` that redirects to https://discord.gg/5xBQmjWm
<img width="494" height="270" alt="image" src="https://github.com/user-attachments/assets/342149e4-e54f-4ecb-9a47-70ec034ac55c" />
