### PR TITLE
chore(config): use import aliases instead of relative imports

### DIFF
--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -13,7 +13,13 @@
     "allowJs": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+
+    /* Import alias */
+    "baseUrl": "..",
+    "paths": {
+      "@functions/*": ["functions/*"]
+    }
   },
   "include": ["**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules", "dist"]

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -13,13 +13,7 @@
     "allowJs": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "forceConsistentCasingInFileNames": true,
-
-    /* Import alias */
-    "baseUrl": "..",
-    "paths": {
-      "@functions/*": ["functions/*"]
-    }
+    "forceConsistentCasingInFileNames": true
   },
   "include": ["**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules", "dist"]

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -18,7 +18,13 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+
+    /* Import alias */
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
   },
   "include": ["src"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,15 @@
 import { defineConfig } from 'vite';
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
+import path from 'path';
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src/*'),
+      '@functions': path.resolve(__dirname, '@./functions/*'),
+    },
+  },
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,7 +9,6 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, 'src'),
-      '@functions': path.resolve(__dirname, '@./functions/*'),
     },
   },
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   plugins: [react(), tailwindcss()],
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, './src/*'),
+      '@': path.resolve(__dirname, 'src'),
       '@functions': path.resolve(__dirname, '@./functions/*'),
     },
   },


### PR DESCRIPTION
Added @ and @functions path aliases in tsconfig.json files and vite.config.ts