### PR TITLE
fix: eliminate sharp edges around hero section search input

### DIFF
--- a/src/components/search/MeilisearchInstantSearch.css
+++ b/src/components/search/MeilisearchInstantSearch.css
@@ -13,7 +13,8 @@
 }
 
 .ais-SearchBox-form {
-  background-color: none;
+  background-color: transparent;
+  border-radius: 100px; /* fallback for background-color: transparent; */
   height: auto;
   line-height: auto;
 }


### PR DESCRIPTION
This fix aims to improve visual fidelity for the hero section by authoring a small fix to the CSS for `src/components/search/MeilisearchInstantSearch.tsx` in `src/components/search/MeilisearchInstantSearch.css`.