### PR TITLE
[FIX] UI: Government branches hover and active color

### DIFF
--- a/src/pages/government/layout.tsx
+++ b/src/pages/government/layout.tsx
@@ -8,6 +8,7 @@ import {
   BookOpen,
   MapPin,
 } from 'lucide-react'
+import clsx from 'clsx'
 
 interface GovernmentLayoutProps {
   title: string
@@ -137,11 +138,12 @@ export default function GovernmentLayout({ children }: GovernmentLayoutProps) {
               <Link
                 key={branch.path}
                 to={branch.path}
-                className={`flex flex-col px-3 md:px-4 py-3 md:py-4 transition-all rounded-md shadow-sm ${
+                className={clsx(
+                  'group flex flex-col p-3 md:p-4 transition-all rounded-md shadow-sm',
                   isActive
-                    ? `${branch.color} text-white`
-                    : `bg-white border ${branch.textColor} ${branch.hoverColor} hover:text-white`
-                }`}
+                    ? [branch.color, 'text-white']
+                    : ['bg-white border', branch.textColor, branch.hoverColor, 'hover:text-white']
+                )}
               >
                 <div className="flex items-center gap-1 mb-1">
                   <div className="mr-2 text-xs md:text-sm">{branch.icon}</div>
@@ -149,7 +151,10 @@ export default function GovernmentLayout({ children }: GovernmentLayoutProps) {
                     {branch.title}
                   </span>
                 </div>
-                <div className="text-xs md:text-sm text-gray-800">
+                <div className={clsx(
+                  'text-xs md:text-sm transition-colors',
+                  isActive ? 'text-white' : 'text-gray-800 group-hover:text-white'
+                )}>
                   {branch.description}
                 </div>
               </Link>


### PR DESCRIPTION
### What this PR does?
- [x] Fix government branches hover and active color
- [x] Use existing clsx library for conditional rendering of styles

Before:
<img width="2044" height="522" alt="image" src="https://github.com/user-attachments/assets/602117a0-f90d-45cc-bde6-7d5550cc176f" />

After:
<img width="1983" height="497" alt="image" src="https://github.com/user-attachments/assets/0fb07f83-abd0-4fb3-9b43-a22bb556ee07" />
<img width="1996" height="483" alt="image" src="https://github.com/user-attachments/assets/bc3c9f3a-327c-4539-aaf4-04283bc33f82" />
