### PR TITLE
feat: translate visa and about page

### DIFF
--- a/public/locales/en/about.json
+++ b/public/locales/en/about.json
@@ -1,0 +1,92 @@
+{
+  "title": "About BetterGov.ph",
+  "whyBuilding": {
+    "title": "Why We're Building This Project",
+    "intro": "The current state of Philippine government websites, particularly the main portal",
+    "govPhLink": "www.gov.ph",
+    "challenges": ", presents numerous challenges for citizens:",
+    "challengesList": [
+      "It would benefit from regular content updates to ensure citizens have access to the most current information and services.",
+      "There's an opportunity to improve user navigation by reviewing and updating links, as well as streamlining pathways to help visitors find what they need more easily.",
+      "Implementing consistent design standards and formatting across all pages could create a more cohesive and professional user experience.",
+      "Enhancing accessibility features and overall user experience would make government services more inclusive and user-friendly for all citizens.",
+      "These improvements could serve as a model for other government agency websites, creating a more unified and effective digital government presence."
+    ],
+    "conclusion": "These issues create barriers for citizens trying to access essential government services and information."
+  },
+  "mission": {
+    "title": "Our Mission",
+    "intro": "We are a volunteer-led initiative with a clear mission: to provide a 'better' website for the Philippines.",
+    "goalsIntro": "Our goals include:",
+    "goalsList": [
+      "Building a volunteer-run website that reflects Filipino values and culture",
+      "Creating intuitive navigation and search functionality",
+      "Ensuring accessibility for all citizens, including those with disabilities",
+      "Providing accurate, up-to-date information about government services",
+      "Establishing a model for how government digital services can and should work"
+    ]
+  },
+  "features": {
+    "title": "Features",
+    "list": [
+      "Modern, responsive design that works on all devices",
+      "Comprehensive directory of government services and agencies",
+      "User-friendly navigation and search",
+      "Accessibility features for users with disabilities",
+      "Regular updates and maintenance"
+    ]
+  },
+  "volunteer": {
+    "title": "Join Us as a Volunteer",
+    "intro": "We're always looking for passionate individuals to help improve BetterGov.ph. We need volunteers with various skills:",
+    "technical": {
+      "title": "Technical",
+      "skills": [
+        "Frontend and backend developers",
+        "UX/UI designers",
+        "Accessibility experts",
+        "QA testers"
+      ]
+    },
+    "content": {
+      "title": "Content",
+      "skills": [
+        "Content writers and editors",
+        "Translators (for Filipino and other local languages)",
+        "Project managers",
+        "Researchers"
+      ]
+    },
+    "callToAction": {
+      "title": "Ready to make a difference?",
+      "description": "If you're interested in contributing, please reach out to us at",
+      "email": "volunteers@bettergov.ph",
+      "alternative": "or open an issue in our repository."
+    }
+  },
+  "bugReport": {
+    "title": "Report a Bug",
+    "intro": "Found a problem with the website? Help us improve by reporting it!",
+    "steps": [
+      "Open an issue in our repository",
+      "Use the bug report template",
+      "Provide as much detail as possible, including:"
+    ],
+    "bugDetails": [
+      "What you were trying to do",
+      "What you expected to happen",
+      "What actually happened",
+      "Screenshots if applicable"
+    ],
+    "alternative": {
+      "text": "Alternatively, email us at",
+      "email": "bugs@bettergov.ph"
+    }
+  },
+  "license": {
+    "title": "License",
+    "description": "This project is released under the",
+    "ccLink": "Creative Commons CC0",
+    "explanation": "dedication. This means the work is dedicated to the public domain and can be freely used by anyone for any purpose without restriction under copyright law."
+  }
+}

--- a/public/locales/en/visa.json
+++ b/public/locales/en/visa.json
@@ -1,0 +1,70 @@
+{
+  "hero": {
+    "title": "Philippines Visa Information",
+    "subtitle": "Find out if you need a visa to visit the Philippines and learn about entry requirements.",
+    "dataSource": "Official data from the Bureau of Immigration and Philippine Department of Foreign Affairs",
+    "checkVisaTypes": "Check visa types"
+  },
+  "quickCheck": {
+    "title": "Quick Visa Check",
+    "description": "Select your country of citizenship to check visa requirements for traveling to the Philippines.",
+    "searchPlaceholder": "Search your country...",
+    "searchAriaLabel": "Search for a country"
+  },
+  "countryList": {
+    "title": "Select Your Country",
+    "noResults": "No countries found matching your search.",
+    "ariaLabel": "Country list"
+  },
+  "requirements": {
+    "title": "Visa Requirements for {{country}}",
+    "visaFree": {
+      "title": "Visa-Free Entry",
+      "description": "Citizens of {{country}} can enter the Philippines without a visa for up to {{duration}}."
+    },
+    "visaRequired": {
+      "title": "Visa Required",
+      "description": "Citizens of {{country}} need to apply for a visa before traveling to the Philippines."
+    },
+    "specialCondition": {
+      "title": "Special Conditions Apply",
+      "description": "Citizens of {{country}} may enter the Philippines without a visa for up to {{duration}} under specific conditions."
+    },
+    "entryRequirements": "Entry Requirements",
+    "requiredDocuments": "Required Documents:",
+    "note": "Note:"
+  },
+  "visaApplication": {
+    "title": "How to Apply for a Visa",
+    "eVisa": {
+      "title": "eVisa Portal",
+      "description": "Apply online through the official eVisa system",
+      "action": "Visit website"
+    },
+    "embassy": {
+      "title": "Philippine Embassies",
+      "description": "Find your nearest Philippine Embassy or Consulate",
+      "action": "Find locations"
+    }
+  },
+  "defaultMessage": {
+    "title": "Check Your Visa Requirements",
+    "description": "Select your country from the list to check if you need a visa to visit the Philippines and learn about entry requirements."
+  },
+  "additionalInfo": {
+    "title": "Important Visa Information",
+    "temporaryVisa": {
+      "title": "Temporary Visitor's Visa (9a)",
+      "description": "The 9(a) Temporary Visitor's Visa is for foreign nationals visiting the Philippines for business, tourism, medical treatment, or other temporary purposes.",
+      "learnMore": "Learn more about Temporary Visitor's Visa"
+    },
+    "visaExtensions": {
+      "title": "Visa Extensions",
+      "description": "Visitors who wish to extend their stay in the Philippines beyond their authorized period can apply for an extension at the Bureau of Immigration.",
+      "visitWebsite": "Visit Bureau of Immigration website"
+    },
+    "disclaimer": {
+      "title": "Disclaimer"
+    }
+  }
+}

--- a/public/locales/fil/about.json
+++ b/public/locales/fil/about.json
@@ -1,0 +1,92 @@
+{
+  "title": "Tungkol sa BetterGov.ph",
+  "whyBuilding": {
+    "title": "Bakit Ginagawa Namin Ang Proyektong Ito",
+    "intro": "Ang kasalukuyang estado ng mga website ng gobyerno ng Pilipinas, lalo na ang pangunahing portal",
+    "govPhLink": "www.gov.ph",
+    "challenges": ", ay nagdudulot ng maraming hamon para sa mga mamamayan:",
+    "challengesList": [
+      "Makakabuti kung may regular na pag-update ng content para masiguro na may access ang mga mamamayan sa pinakabagong impormasyon at serbisyo.",
+      "May pagkakataon na mapabuti ang user navigation sa pamamagitan ng pagsusuri at pag-update ng mga link, pati na rin ang pag-streamline ng mga pathway para mas madaling mahanap ng mga visitor ang kanilang kailangan.",
+      "Ang pagpapatupad ng consistent na design standards at formatting sa lahat ng pages ay makakalikha ng mas cohesive at professional na user experience.",
+      "Ang pagpapahusay ng accessibility features at overall user experience ay gagawing mas inclusive at user-friendly ang mga government services para sa lahat ng mamamayan.",
+      "Ang mga pagpapabuting ito ay maaaring magsilbing modelo para sa iba pang government agency websites, na lilikha ng mas unified at effective na digital government presence."
+    ],
+    "conclusion": "Ang mga isyung ito ay lumilikha ng mga hadlang para sa mga mamamayang sumusubok na ma-access ang mga mahahalagang government services at impormasyon."
+  },
+  "mission": {
+    "title": "Ang Aming Misyon",
+    "intro": "Kami ay isang volunteer-led initiative na may malinaw na misyon: magbigay ng 'mas magandang' website para sa Pilipinas.",
+    "goalsIntro": "Ang aming mga layunin ay kinabibilangan ng:",
+    "goalsList": [
+      "Pagbuo ng volunteer-run website na sumasalamin sa mga pagpapahalaga at kultura ng mga Pilipino",
+      "Paglikha ng intuitive navigation at search functionality",
+      "Pagsiguro ng accessibility para sa lahat ng mamamayan, kasama ang mga may kapansanan",
+      "Pagbibigay ng tumpak at up-to-date na impormasyon tungkol sa mga government services",
+      "Pagtatatag ng modelo kung paano dapat gumagana ang mga government digital services"
+    ]
+  },
+  "features": {
+    "title": "Mga Feature",
+    "list": [
+      "Modernong, responsive design na gumagana sa lahat ng devices",
+      "Komprehensibong directory ng government services at agencies",
+      "User-friendly navigation at search",
+      "Accessibility features para sa mga users na may kapansanan",
+      "Regular na updates at maintenance"
+    ]
+  },
+  "volunteer": {
+    "title": "Sumali sa Amin Bilang Volunteer",
+    "intro": "Lagi kaming naghahanap ng mga passionate na indibidwal na tutulong na mapabuti ang BetterGov.ph. Kailangan namin ng mga volunteers na may iba't ibang skills:",
+    "technical": {
+      "title": "Technical",
+      "skills": [
+        "Frontend at backend developers",
+        "UX/UI designers",
+        "Accessibility experts",
+        "QA testers"
+      ]
+    },
+    "content": {
+      "title": "Content",
+      "skills": [
+        "Content writers at editors",
+        "Mga translator (para sa Filipino at iba pang local languages)",
+        "Project managers",
+        "Mga researcher"
+      ]
+    },
+    "callToAction": {
+      "title": "Handa na bang gumawa ng pagbabago?",
+      "description": "Kung interesado kayong mag-contribute, mangyaring makipag-ugnayan sa amin sa",
+      "email": "volunteers@bettergov.ph",
+      "alternative": "o mag-open ng issue sa aming repository."
+    }
+  },
+  "bugReport": {
+    "title": "Mag-report ng Bug",
+    "intro": "Nahanap ninyo ang problema sa website? Tulungan ninyo kaming mapabuti ito sa pamamagitan ng pag-report!",
+    "steps": [
+      "Mag-open ng issue sa aming repository",
+      "Gamitin ang bug report template",
+      "Magbigay ng kasing-detalyado na impormasyon, kasama ang:"
+    ],
+    "bugDetails": [
+      "Ano ang sinusubukan ninyong gawin",
+      "Ano ang inaasahan ninyong mangyayari",
+      "Ano ang talagang nangyari",
+      "Mga screenshot kung applicable"
+    ],
+    "alternative": {
+      "text": "Alternatibong paraan, mag-email sa amin sa",
+      "email": "bugs@bettergov.ph"
+    }
+  },
+  "license": {
+    "title": "License",
+    "description": "Ang proyektong ito ay inilabas sa ilalim ng",
+    "ccLink": "Creative Commons CC0",
+    "explanation": "dedication. Ibig sabihin nito na ang gawa ay inilaan sa public domain at maaaring malayang gamitin ng sinuman para sa anumang layunin nang walang paghihigpit sa ilalim ng copyright law."
+  }
+}

--- a/public/locales/fil/visa.json
+++ b/public/locales/fil/visa.json
@@ -1,0 +1,70 @@
+{
+  "hero": {
+    "title": "Impormasyon sa Visa ng Pilipinas",
+    "subtitle": "Alamin kung kailangan mo ng visa para bisitahin ang Pilipinas at matuto tungkol sa mga kinakailangan sa pagpasok.",
+    "dataSource": "Opisyal na datos mula sa Bureau of Immigration at Philippine Department of Foreign Affairs",
+    "checkVisaTypes": "Tignan ang mga uri ng visa"
+  },
+  "quickCheck": {
+    "title": "Mabilis na Pagsusuri ng Visa",
+    "description": "Piliin ang inyong bansa ng pagkamamamayan upang suriin ang mga kinakailangan sa visa para sa paglalakbay sa Pilipinas.",
+    "searchPlaceholder": "Hanapin ang inyong bansa...",
+    "searchAriaLabel": "Maghanap ng bansa"
+  },
+  "countryList": {
+    "title": "Piliin ang Inyong Bansa",
+    "noResults": "Walang nahanap na bansa na tumugma sa inyong paghahanap.",
+    "ariaLabel": "Listahan ng mga bansa"
+  },
+  "requirements": {
+    "title": "Mga Kinakailangan sa Visa para sa {{country}}",
+    "visaFree": {
+      "title": "Walang Kinakailangang Visa",
+      "description": "Ang mga mamamayan ng {{country}} ay maaaring pumasok sa Pilipinas nang walang visa hanggang sa {{duration}}."
+    },
+    "visaRequired": {
+      "title": "Kinakailangan ang Visa",
+      "description": "Ang mga mamamayan ng {{country}} ay kailangang mag-apply para sa visa bago maglakbay sa Pilipinas."
+    },
+    "specialCondition": {
+      "title": "May Mga Natatanging Kondisyon",
+      "description": "Ang mga mamamayan ng {{country}} ay maaaring pumasok sa Pilipinas nang walang visa hanggang sa {{duration}} sa ilalim ng mga tukoy na kondisyon."
+    },
+    "entryRequirements": "Mga Kinakailangan sa Pagpasok",
+    "requiredDocuments": "Mga Kinakailangang Dokumento:",
+    "note": "Tala:"
+  },
+  "visaApplication": {
+    "title": "Paano Mag-apply para sa Visa",
+    "eVisa": {
+      "title": "eVisa Portal",
+      "description": "Mag-apply online sa pamamagitan ng opisyal na eVisa system",
+      "action": "Bisitahin ang website"
+    },
+    "embassy": {
+      "title": "Mga Embassy ng Pilipinas",
+      "description": "Hanapin ang pinakamalapit na Embassy o Consulate ng Pilipinas",
+      "action": "Hanapin ang mga lokasyon"
+    }
+  },
+  "defaultMessage": {
+    "title": "Suriin ang Inyong Mga Kinakailangan sa Visa",
+    "description": "Piliin ang inyong bansa mula sa listahan upang suriin kung kailangan ninyo ng visa para bisitahin ang Pilipinas at matuto tungkol sa mga kinakailangan sa pagpasok."
+  },
+  "additionalInfo": {
+    "title": "Mahalagang Impormasyon sa Visa",
+    "temporaryVisa": {
+      "title": "Temporary Visitor's Visa (9a)",
+      "description": "Ang 9(a) Temporary Visitor's Visa ay para sa mga dayuhang nasyonal na bumibisita sa Pilipinas para sa negosyo, turismo, medikal na paggamot, o iba pang pansamantalang layunin.",
+      "learnMore": "Matuto pa tungkol sa Temporary Visitor's Visa"
+    },
+    "visaExtensions": {
+      "title": "Mga Pagpapalawak ng Visa",
+      "description": "Ang mga bisita na nais magpahaba ng kanilang pananatili sa Pilipinas lampas sa kanilang awtorisadong panahon ay maaaring mag-apply para sa extension sa Bureau of Immigration.",
+      "visitWebsite": "Bisitahin ang website ng Bureau of Immigration"
+    },
+    "disclaimer": {
+      "title": "Disclaimer"
+    }
+  }
+}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -11,7 +11,7 @@ i18n
     fallbackLng: 'en',
     debug: false,
     defaultNS: 'common',
-    ns: ['common'],
+    ns: ['common', 'visa'],
 
     backend: {
       loadPath: '/locales/{{lng}}/{{ns}}.json',

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -11,7 +11,7 @@ i18n
     fallbackLng: 'en',
     debug: false,
     defaultNS: 'common',
-    ns: ['common', 'visa'],
+    ns: ['common', 'visa', 'about'],
 
     backend: {
       loadPath: '/locales/{{lng}}/{{ns}}.json',

--- a/src/i18n/languages.ts
+++ b/src/i18n/languages.ts
@@ -4,31 +4,21 @@ export interface LanguageInfo {
   code: LanguageType
   name: string
   nativeName: string
-  enabled: boolean
 }
 
 export const LANGUAGES: Record<LanguageType, LanguageInfo> = {
-  en: { code: 'en', name: 'English', nativeName: 'English', enabled: true },
-  fil: { code: 'fil', name: 'Filipino/Tagalog', nativeName: 'Filipino/Tagalog', enabled: true },
-  ceb: { code: 'ceb', name: 'Cebuano', nativeName: 'Bisaya/Sinugboanon', enabled: true },
-  ilo: { code: 'ilo', name: 'Ilocano', nativeName: 'Ilokano', enabled: true },
-  hil: { code: 'hil', name: 'Hiligaynon', nativeName: 'Ilonggo', enabled: true },
-  war: { code: 'war', name: 'Waray', nativeName: 'Waray-Waray', enabled: false },
-  pam: { code: 'pam', name: 'Kapampangan', nativeName: 'Kapampangan', enabled: false },
-  bcl: { code: 'bcl', name: 'Bikol', nativeName: 'Bikol Central', enabled: false },
-  pag: { code: 'pag', name: 'Pangasinan', nativeName: 'Pangasinan', enabled: false },
-  tgl: { code: 'tgl', name: 'Tagalog', nativeName: 'Tagalog', enabled: false }, // Alias for fil
-  mag: { code: 'mag', name: 'Maguindanao', nativeName: 'Maguindanaon', enabled: false },
-  tsg: { code: 'tsg', name: 'Tausug', nativeName: 'Bahasa Sūg', enabled: false },
-  mdh: { code: 'mdh', name: 'Maranao', nativeName: 'Meranaw', enabled: false },
-}
-
-export const ENABLED_LANGUAGES = Object.values(LANGUAGES).filter(lang => lang.enabled)
-
-// Normalize language codes (fil and tgl are the same)
-export const normalizeLanguage = (lang: LanguageType): LanguageType => {
-  if (lang === 'tgl') return 'fil'
-  return lang
+  en: { code: 'en', name: 'English', nativeName: 'English' },
+  fil: { code: 'fil', name: 'Tagalog', nativeName: 'Filipino/Tagalog' },
+  ceb: { code: 'ceb', name: 'Cebuano', nativeName: 'Bisaya/Sinugboanon' },
+  ilo: { code: 'ilo', name: 'Ilocano', nativeName: 'Ilokano' },
+  hil: { code: 'hil', name: 'Hiligaynon', nativeName: 'Ilonggo' },
+  war: { code: 'war', name: 'Waray', nativeName: 'Waray-Waray' },
+  pam: { code: 'pam', name: 'Kapampangan', nativeName: 'Kapampangan' },
+  bcl: { code: 'bcl', name: 'Bikol', nativeName: 'Bikol Central' },
+  pag: { code: 'pag', name: 'Pangasinan', nativeName: 'Pangasinan' },
+  mag: { code: 'mag', name: 'Maguindanao', nativeName: 'Maguindanaon' },
+  tsg: { code: 'tsg', name: 'Tausug', nativeName: 'Bahasa Sūg' },
+  mdh: { code: 'mdh', name: 'Maranao', nativeName: 'Meranaw' },
 }
 
 export const DEFAULT_LANGUAGE: LanguageType = 'en'

--- a/src/pages/about/index.tsx
+++ b/src/pages/about/index.tsx
@@ -1,144 +1,108 @@
 import React from 'react'
+import { useTranslation } from 'react-i18next'
 import { Mail, AlertTriangle, Users, Heart } from 'lucide-react'
 
 const AboutPage: React.FC = () => {
+  const { t } = useTranslation('about')
   return (
     <div className="min-h-screen bg-gray-50">
       <div className="container mx-auto px-4 py-6 md:py-8">
         <div className="bg-white rounded-lg border shadow-sm p-6 md:p-8 md:py-24 mt-4">
           <div className="max-w-3xl mx-auto">
             <h1 className="text-3xl md:text-4xl font-bold text-gray-900 mb-6">
-              About BetterGov.ph
+              {t('title')}
             </h1>
 
             <div className="prose prose-lg max-w-none">
               <section className="mb-10">
                 <h2 className="text-2xl font-bold text-gray-800 mb-4">
-                  Why We're Building This Project
+                  {t('whyBuilding.title')}
                 </h2>
                 <p className="mb-4 text-gray-700">
-                  The current state of Philippine government websites,
-                  particularly the main portal
+                  {t('whyBuilding.intro')}
                   <a
                     href="https://www.gov.ph"
                     className="text-blue-600 hover:text-blue-800 mx-1"
                   >
-                    www.gov.ph
+                    {t('whyBuilding.govPhLink')}
                   </a>
-                  , presents numerous challenges for citizens:
+                  {t('whyBuilding.challenges')}
                 </p>
                 <ul className="list-disc pl-6 mb-6 text-gray-700 leading-relaxed">
-                  <li className="mb-2">
-                    It would benefit from regular content updates to ensure
-                    citizens have access to the most current information and
-                    services.
-                  </li>
-                  <li className="mb-2">
-                    There's an opportunity to improve user navigation by
-                    reviewing and updating links, as well as streamlining
-                    pathways to help visitors find what they need more easily.
-                  </li>
-                  <li className="mb-2">
-                    Implementing consistent design standards and formatting
-                    across all pages could create a more cohesive and
-                    professional user experience.
-                  </li>
-                  <li className="mb-2">
-                    Enhancing accessibility features and overall user experience
-                    would make government services more inclusive and
-                    user-friendly for all citizens.
-                  </li>
-                  <li className="mb-2">
-                    These improvements could serve as a model for other
-                    government agency websites, creating a more unified and
-                    effective digital government presence.
-                  </li>
+                  {(
+                    t('whyBuilding.challengesList', {
+                      returnObjects: true,
+                    }) as string[]
+                  ).map((challenge: string, index: number) => (
+                    <li key={index} className="mb-2">
+                      {challenge}
+                    </li>
+                  ))}
                 </ul>
-                <p className="text-gray-700">
-                  These issues create barriers for citizens trying to access
-                  essential government services and information.
-                </p>
+                <p className="text-gray-700">{t('whyBuilding.conclusion')}</p>
               </section>
 
               <section className="mb-10">
                 <h2 className="text-2xl font-bold text-gray-800 mb-4">
-                  Our Mission
+                  {t('mission.title')}
                 </h2>
-                <p className="mb-4 text-gray-700">
-                  We are a volunteer-led initiative with a clear mission: to
-                  provide a 'better' website for the Philippines.
-                </p>
-                <p className="mb-4 text-gray-700">Our goals include:</p>
+                <p className="mb-4 text-gray-700">{t('mission.intro')}</p>
+                <p className="mb-4 text-gray-700">{t('mission.goalsIntro')}</p>
                 <ul className="list-disc pl-6 mb-6 text-gray-700">
-                  <li>
-                    Building a volunteer-run website that reflects Filipino
-                    values and culture
-                  </li>
-                  <li>
-                    Creating intuitive navigation and search functionality
-                  </li>
-                  <li>
-                    Ensuring accessibility for all citizens, including those
-                    with disabilities
-                  </li>
-                  <li>
-                    Providing accurate, up-to-date information about government
-                    services
-                  </li>
-                  <li>
-                    Establishing a model for how government digital services can
-                    and should work
-                  </li>
+                  {(
+                    t('mission.goalsList', { returnObjects: true }) as string[]
+                  ).map((goal: string, index: number) => (
+                    <li key={index}>{goal}</li>
+                  ))}
                 </ul>
               </section>
 
               <section className="mb-10">
                 <h2 className="text-2xl font-bold text-gray-800 mb-4">
-                  Features
+                  {t('features.title')}
                 </h2>
                 <ul className="list-disc pl-6 mb-6 text-gray-700">
-                  <li>Modern, responsive design that works on all devices</li>
-                  <li>
-                    Comprehensive directory of government services and agencies
-                  </li>
-                  <li>User-friendly navigation and search</li>
-                  <li>Accessibility features for users with disabilities</li>
-                  <li>Regular updates and maintenance</li>
+                  {(
+                    t('features.list', { returnObjects: true }) as string[]
+                  ).map((feature: string, index: number) => (
+                    <li key={index}>{feature}</li>
+                  ))}
                 </ul>
               </section>
 
               <section className="mb-10">
                 <h2 className="flex items-center text-2xl font-bold text-gray-800 mb-4">
                   <Users className="mr-2 h-6 w-6 text-blue-600" />
-                  Join Us as a Volunteer
+                  {t('volunteer.title')}
                 </h2>
-                <p className="mb-4 text-gray-700">
-                  We're always looking for passionate individuals to help
-                  improve BetterGov.ph. We need volunteers with various skills:
-                </p>
+                <p className="mb-4 text-gray-700">{t('volunteer.intro')}</p>
                 <div className="grid md:grid-cols-2 gap-4 mb-6">
                   <div className="bg-blue-50 p-4 rounded-lg">
                     <h3 className="font-semibold text-gray-800 mb-2">
-                      Technical
+                      {t('volunteer.technical.title')}
                     </h3>
                     <ul className="list-disc pl-6 text-gray-700">
-                      <li>Frontend and backend developers</li>
-                      <li>UX/UI designers</li>
-                      <li>Accessibility experts</li>
-                      <li>QA testers</li>
+                      {(
+                        t('volunteer.technical.skills', {
+                          returnObjects: true,
+                        }) as string[]
+                      ).map((skill: string, index: number) => (
+                        <li key={index}>{skill}</li>
+                      ))}
                     </ul>
                   </div>
                   <div className="bg-green-50 p-4 rounded-lg">
                     <h3 className="font-semibold text-gray-800 mb-2">
-                      Content
+                      {t('volunteer.content.title')}
                     </h3>
                     <ul className="list-disc pl-6 text-gray-700">
-                      <li>Content writers and editors</li>
-                      <li>
-                        Translators (for Filipino and other local languages)
-                      </li>
-                      <li>Project managers</li>
-                      <li>Researchers</li>
+                      {(
+                        t('volunteer.content.skills', {
+                          returnObjects: true,
+                        }) as string[]
+                      ).map((skill: string, index: number) => (
+                        <li key={index}>{skill}</li>
+                      ))}
                     </ul>
                   </div>
                 </div>
@@ -146,18 +110,17 @@ const AboutPage: React.FC = () => {
                   <Heart className="h-6 w-6 text-red-500 mr-3 flex-shrink-0 mt-1" />
                   <div>
                     <p className="font-medium text-gray-800 mb-2">
-                      Ready to make a difference?
+                      {t('volunteer.callToAction.title')}
                     </p>
                     <p className="text-gray-700 mb-4">
-                      If you're interested in contributing, please reach out to
-                      us at
+                      {t('volunteer.callToAction.description')}
                       <a
                         href="mailto:volunteers@bettergov.ph"
                         className="text-blue-600 hover:text-blue-800 mx-1"
                       >
-                        volunteers@bettergov.ph
+                        {t('volunteer.callToAction.email')}
                       </a>
-                      or open an issue in our repository.
+                      {t('volunteer.callToAction.alternative')}
                     </p>
                   </div>
                 </div>
@@ -166,34 +129,38 @@ const AboutPage: React.FC = () => {
               <section className="mb-10">
                 <h2 className="flex items-center text-2xl font-bold text-gray-800 mb-4">
                   <AlertTriangle className="mr-2 h-6 w-6 text-amber-500" />
-                  Report a Bug
+                  {t('bugReport.title')}
                 </h2>
-                <p className="mb-4 text-gray-700">
-                  Found a problem with the website? Help us improve by reporting
-                  it!
-                </p>
+                <p className="mb-4 text-gray-700">{t('bugReport.intro')}</p>
                 <ol className="list-decimal pl-6 mb-6 text-gray-700">
-                  <li>Open an issue in our repository</li>
-                  <li>Use the bug report template</li>
-                  <li>
-                    Provide as much detail as possible, including:
-                    <ul className="list-disc pl-6 mt-2">
-                      <li>What you were trying to do</li>
-                      <li>What you expected to happen</li>
-                      <li>What actually happened</li>
-                      <li>Screenshots if applicable</li>
-                    </ul>
-                  </li>
+                  {(
+                    t('bugReport.steps', { returnObjects: true }) as string[]
+                  ).map((step: string, index: number) => (
+                    <li key={index}>
+                      {step}
+                      {index === 2 && (
+                        <ul className="list-disc pl-6 mt-2">
+                          {(
+                            t('bugReport.bugDetails', {
+                              returnObjects: true,
+                            }) as string[]
+                          ).map((detail: string, detailIndex: number) => (
+                            <li key={detailIndex}>{detail}</li>
+                          ))}
+                        </ul>
+                      )}
+                    </li>
+                  ))}
                 </ol>
                 <div className="bg-amber-50 p-4 rounded-lg flex items-center">
                   <Mail className="h-5 w-5 text-amber-600 mr-2" />
                   <p className="text-gray-700">
-                    Alternatively, email us at
+                    {t('bugReport.alternative.text')}
                     <a
                       href="mailto:bugs@bettergov.ph"
                       className="text-blue-600 hover:text-blue-800 mx-1"
                     >
-                      bugs@bettergov.ph
+                      {t('bugReport.alternative.email')}
                     </a>
                   </p>
                 </div>
@@ -201,19 +168,17 @@ const AboutPage: React.FC = () => {
 
               <section>
                 <h2 className="text-2xl font-bold text-gray-800 mb-4">
-                  License
+                  {t('license.title')}
                 </h2>
                 <p className="mb-4 text-gray-700">
-                  This project is released under the
+                  {t('license.description')}
                   <a
                     href="https://creativecommons.org/publicdomain/zero/1.0/"
                     className="text-blue-600 hover:text-blue-800 mx-1"
                   >
-                    Creative Commons CC0
+                    {t('license.ccLink')}
                   </a>
-                  dedication. This means the work is dedicated to the public
-                  domain and can be freely used by anyone for any purpose
-                  without restriction under copyright law.
+                  {t('license.explanation')}
                 </p>
               </section>
             </div>

--- a/src/pages/travel/visa/index.tsx
+++ b/src/pages/travel/visa/index.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
 import {
   Compass,
   FileCheck,
@@ -17,6 +18,7 @@ type Country = string
 // Using the imported VisaRequirement type from '../../../types/visa'
 
 const VisaPage: React.FC = () => {
+  const { t } = useTranslation('visa')
   const [searchTerm, setSearchTerm] = useState<string>('')
   const [selectedCountry, setSelectedCountry] = useState<string | null>(null)
   const [visaRequirement, setVisaRequirement] =
@@ -159,22 +161,16 @@ const VisaPage: React.FC = () => {
           <div className="flex flex-col md:flex-row items-center justify-between">
             <div className="md:w-1/2 mb-8 md:mb-0">
               <h1 className="text-4xl md:text-5xl font-bold mb-4">
-                Philippines Visa Information
+                {t('hero.title')}
               </h1>
-              <p className="text-xl opacity-90 mb-6">
-                Find out if you need a visa to visit the Philippines and learn
-                about entry requirements.
-              </p>
+              <p className="text-xl opacity-90 mb-6">{t('hero.subtitle')}</p>
               <div className="flex items-center space-x-2 text-sm">
                 <Globe className="h-4 w-4" />
-                <span>
-                  Official data from the Bureau of Immigration and Philippine
-                  Department of Foreign Affairs
-                </span>
+                <span>{t('hero.dataSource')}</span>
               </div>
               <Link to="/travel/visa-types">
                 <Button className="text-xl bg-blue-800 py-8 px-8 mt-6">
-                  Check visa types
+                  {t('hero.checkVisaTypes')}
                 </Button>
               </Link>
             </div>
@@ -182,21 +178,20 @@ const VisaPage: React.FC = () => {
               <div className="bg-white rounded-lg shadow-lg p-6 text-gray-800">
                 <h2 className="text-xl font-semibold mb-4 flex items-center">
                   <Compass className="mr-2 h-5 w-5 text-blue-600" />
-                  Quick Visa Check
+                  {t('quickCheck.title')}
                 </h2>
                 <p className="text-sm text-gray-800 mb-4">
-                  Select your country of citizenship to check visa requirements
-                  for traveling to the Philippines.
+                  {t('quickCheck.description')}
                 </p>
                 <div className="relative">
                   <Search className="absolute left-3 top-3 h-5 w-5 text-gray-400" />
                   <input
                     type="text"
-                    placeholder="Search your country..."
+                    placeholder={t('quickCheck.searchPlaceholder')}
                     className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
                     value={searchTerm}
                     onChange={(e) => setSearchTerm(e.target.value)}
-                    aria-label="Search for a country"
+                    aria-label={t('quickCheck.searchAriaLabel')}
                   />
                 </div>
               </div>
@@ -212,12 +207,12 @@ const VisaPage: React.FC = () => {
           <div className="md:col-span-1">
             <div className="bg-white rounded-lg shadow-md p-6">
               <h2 className="text-xl font-semibold mb-4">
-                Select Your Country
+                {t('countryList.title')}
               </h2>
               <div
                 className="h-[800px] overflow-y-auto pr-2"
                 role="listbox"
-                aria-label="Country list"
+                aria-label={t('countryList.ariaLabel')}
               >
                 {filteredCountries.length > 0 ? (
                   filteredCountries.map((country) => (
@@ -238,7 +233,7 @@ const VisaPage: React.FC = () => {
                 ) : (
                   <div className="text-center py-8 text-gray-800">
                     <Search className="mx-auto h-8 w-8 mb-2 opacity-50" />
-                    <p>No countries found matching your search.</p>
+                    <p>{t('countryList.noResults')}</p>
                   </div>
                 )}
               </div>
@@ -250,7 +245,7 @@ const VisaPage: React.FC = () => {
             {selectedCountry ? (
               <div className="bg-white rounded-lg shadow-md p-6">
                 <h2 className="text-2xl font-semibold mb-2">
-                  Visa Requirements for {selectedCountry}
+                  {t('requirements.title', { country: selectedCountry })}
                 </h2>
 
                 {visaRequirement && (
@@ -260,12 +255,13 @@ const VisaPage: React.FC = () => {
                         <FileCheck className="h-6 w-6 text-green-600 mr-3 mt-0.5" />
                         <div>
                           <h3 className="font-semibold text-green-800">
-                            Visa-Free Entry
+                            {t('requirements.visaFree.title')}
                           </h3>
                           <p className="text-green-700">
-                            Citizens of {selectedCountry} can enter the
-                            Philippines without a visa for up to{' '}
-                            <strong>{visaRequirement.duration}</strong>.
+                            {t('requirements.visaFree.description', {
+                              country: selectedCountry,
+                              duration: visaRequirement.duration,
+                            })}
                           </p>
                         </div>
                       </div>
@@ -276,11 +272,12 @@ const VisaPage: React.FC = () => {
                         <AlertCircle className="h-6 w-6 text-red-600 mr-3 mt-0.5" />
                         <div>
                           <h3 className="font-semibold text-red-800">
-                            Visa Required
+                            {t('requirements.visaRequired.title')}
                           </h3>
                           <p className="text-red-700">
-                            Citizens of {selectedCountry} need to apply for a
-                            visa before traveling to the Philippines.
+                            {t('requirements.visaRequired.description', {
+                              country: selectedCountry,
+                            })}
                           </p>
                         </div>
                       </div>
@@ -291,13 +288,13 @@ const VisaPage: React.FC = () => {
                         <AlertCircle className="h-6 w-6 text-yellow-600 mr-3 mt-0.5" />
                         <div>
                           <h3 className="font-semibold text-yellow-800">
-                            Special Conditions Apply
+                            {t('requirements.specialCondition.title')}
                           </h3>
                           <p className="text-yellow-700">
-                            Citizens of {selectedCountry} may enter the
-                            Philippines without a visa for up to{' '}
-                            <strong>{visaRequirement.duration}</strong> under
-                            specific conditions.
+                            {t('requirements.specialCondition.description', {
+                              country: selectedCountry,
+                              duration: visaRequirement.duration,
+                            })}
                           </p>
                         </div>
                       </div>
@@ -305,7 +302,7 @@ const VisaPage: React.FC = () => {
 
                     <div className="mt-6">
                       <h3 className="text-lg font-medium mb-2">
-                        Entry Requirements
+                        {t('requirements.entryRequirements')}
                       </h3>
                       <div className="prose prose-sm max-w-none">
                         <p>{visaRequirement.description}</p>
@@ -313,7 +310,7 @@ const VisaPage: React.FC = () => {
                         {visaRequirement.requirements && (
                           <div className="mt-4">
                             <h4 className="text-md font-medium mb-2">
-                              Required Documents:
+                              {t('requirements.requiredDocuments')}
                             </h4>
                             <ul className="list-disc pl-5 space-y-1">
                               {visaRequirement.requirements.map(
@@ -328,7 +325,7 @@ const VisaPage: React.FC = () => {
                         {visaRequirement.additionalInfo && (
                           <div className="mt-4 p-3 bg-blue-50 rounded-md text-blue-800">
                             <p>
-                              <strong>Note:</strong>{' '}
+                              <strong>{t('requirements.note')}</strong>{' '}
                               {visaRequirement.additionalInfo}
                             </p>
                           </div>
@@ -339,7 +336,7 @@ const VisaPage: React.FC = () => {
                     {visaRequirement.type === 'visa-required' && (
                       <div className="mt-6">
                         <h3 className="text-lg font-medium mb-3">
-                          How to Apply for a Visa
+                          {t('visaApplication.title')}
                         </h3>
                         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                           <a
@@ -352,12 +349,14 @@ const VisaPage: React.FC = () => {
                               <Globe className="h-5 w-5 text-blue-600" />
                             </div>
                             <div>
-                              <h4 className="font-medium">eVisa Portal</h4>
+                              <h4 className="font-medium">
+                                {t('visaApplication.eVisa.title')}
+                              </h4>
                               <p className="text-sm text-gray-800">
-                                Apply online through the official eVisa system
+                                {t('visaApplication.eVisa.description')}
                               </p>
                               <div className="flex items-center text-blue-600 text-sm mt-1">
-                                <span>Visit website</span>
+                                <span>{t('visaApplication.eVisa.action')}</span>
                                 <ExternalLink className="h-3 w-3 ml-1" />
                               </div>
                             </div>
@@ -373,14 +372,15 @@ const VisaPage: React.FC = () => {
                             </div>
                             <div>
                               <h4 className="font-medium">
-                                Philippine Embassies
+                                {t('visaApplication.embassy.title')}
                               </h4>
                               <p className="text-sm text-gray-800">
-                                Find your nearest Philippine Embassy or
-                                Consulate
+                                {t('visaApplication.embassy.description')}
                               </p>
                               <div className="flex items-center text-blue-600 text-sm mt-1">
-                                <span>Find locations</span>
+                                <span>
+                                  {t('visaApplication.embassy.action')}
+                                </span>
                                 <ExternalLink className="h-3 w-3 ml-1" />
                               </div>
                             </div>
@@ -398,12 +398,10 @@ const VisaPage: React.FC = () => {
                     <Globe className="h-12 w-12 text-blue-600" />
                   </div>
                   <h2 className="text-2xl font-semibold mb-2">
-                    Check Your Visa Requirements
+                    {t('defaultMessage.title')}
                   </h2>
                   <p className="text-gray-800 max-w-md mx-auto">
-                    Select your country from the list to check if you need a
-                    visa to visit the Philippines and learn about entry
-                    requirements.
+                    {t('defaultMessage.description')}
                   </p>
                 </div>
               </div>
@@ -412,18 +410,16 @@ const VisaPage: React.FC = () => {
             {/* Additional Information */}
             <div className="mt-8 bg-white rounded-lg shadow-md p-6">
               <h2 className="text-xl font-semibold mb-4">
-                Important Visa Information
+                {t('additionalInfo.title')}
               </h2>
 
               <div className="space-y-6">
                 <div>
                   <h3 className="text-lg font-medium mb-2">
-                    Temporary Visitor's Visa (9a)
+                    {t('additionalInfo.temporaryVisa.title')}
                   </h3>
                   <p className="text-gray-700">
-                    The 9(a) Temporary Visitor's Visa is for foreign nationals
-                    visiting the Philippines for business, tourism, medical
-                    treatment, or other temporary purposes.
+                    {t('additionalInfo.temporaryVisa.description')}
                   </p>
                   <a
                     href="https://evisa.gov.ph/page/policy?l1=Non-Immigrant%20Visas&l2=9(a)%20Temporary%20Visitors%20Visa"
@@ -431,17 +427,17 @@ const VisaPage: React.FC = () => {
                     rel="noopener noreferrer"
                     className="inline-flex items-center text-blue-600 hover:text-blue-800 mt-2"
                   >
-                    <span>Learn more about Temporary Visitor's Visa</span>
+                    <span>{t('additionalInfo.temporaryVisa.learnMore')}</span>
                     <ExternalLink className="h-3 w-3 ml-1" />
                   </a>
                 </div>
 
                 <div>
-                  <h3 className="text-lg font-medium mb-2">Visa Extensions</h3>
+                  <h3 className="text-lg font-medium mb-2">
+                    {t('additionalInfo.visaExtensions.title')}
+                  </h3>
                   <p className="text-gray-700">
-                    Visitors who wish to extend their stay in the Philippines
-                    beyond their authorized period can apply for an extension at
-                    the Bureau of Immigration.
+                    {t('additionalInfo.visaExtensions.description')}
                   </p>
                   <a
                     href="https://immigration.gov.ph/"
@@ -449,14 +445,16 @@ const VisaPage: React.FC = () => {
                     rel="noopener noreferrer"
                     className="inline-flex items-center text-blue-600 hover:text-blue-800 mt-2"
                   >
-                    <span>Visit Bureau of Immigration website</span>
+                    <span>
+                      {t('additionalInfo.visaExtensions.visitWebsite')}
+                    </span>
                     <ExternalLink className="h-3 w-3 ml-1" />
                   </a>
                 </div>
 
                 <div className="p-4 bg-yellow-50 rounded-lg">
                   <h3 className="text-lg font-medium mb-2 text-yellow-800">
-                    Disclaimer
+                    {t('additionalInfo.disclaimer.title')}
                   </h3>
                   <p className="text-yellow-700 text-sm">
                     {visaData.sourceInfo.disclaimer}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,7 +1,6 @@
 export type LanguageType =
   | 'en'    // English
   | 'fil'   // Filipino (standardized Tagalog)
-  | 'tgl'   // Tagalog (same as Filipino)
   | 'ceb'   // Cebuano/Bisaya
   | 'ilo'   // Ilocano
   | 'hil'   // Hiligaynon/Ilonggo


### PR DESCRIPTION
Allow translation for these pages:
- `/travel/visa`
- `/about`

I can translate to other languages using AI, but aside from I'm not fluent on other languages, I will just let others to contribute. Missing translation will automatically fallback to English because this #37.

## Screenshots
### About
<img width="1744" height="1213" alt="image" src="https://github.com/user-attachments/assets/7e22dbb3-78ac-47f3-8659-41f969753080" />

### Visa
<img width="1337" height="1290" alt="image" src="https://github.com/user-attachments/assets/fbda8bc7-6fb9-40f5-bed0-0059b669314a" />

## Other changes
- Remove unused/redundant translation-related code