### PR TITLE
docs: fix repository clone URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ Alternatively, email us at [bugs@bettergov.ph](mailto:bugs@bettergov.ph)
 
 ```bash
 # Clone the repository
-git clone https://github.com/your-org/bettergov.ph.git
-cd bettergov.ph
+git clone https://github.com/bettergovph/bettergov.git
+cd bettergov
 
 # Install dependencies
 npm install


### PR DESCRIPTION
The Setup section in the README.md shows the incorrect URL for cloning the project's Git repository: `https://github.com/your-org/bettergov.ph.git`. This changes the URL to `https://github.com/bettergovph/bettergov.git` which is the correct URL.