### PR TITLE
fix:navigation ui responsive fix

### DIFF
--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -101,7 +101,7 @@ const Navbar: React.FC = () => {
           </div>
 
           {/* Desktop navigation */}
-          <div className="hidden md:flex items-center space-x-8 pr-24">
+          <div className="hidden lg:flex items-center space-x-8 pr-24">
             {mainNavigation.map((item) => (
               <div key={item.label} className="relative group">
                 <Link
@@ -136,7 +136,7 @@ const Navbar: React.FC = () => {
               </div>
             ))}
           </div>
-          <div className="hidden md:flex items-center space-x-6">
+          <div className="hidden lg:flex items-center space-x-6">
             <Link
               to="/about"
               className="flex items-center text-gray-700 hover:text-primary-600 font-medium transition-colors"
@@ -159,7 +159,7 @@ const Navbar: React.FC = () => {
           </div>
 
           {/* Mobile menu button */}
-          <div className="md:hidden flex items-center">
+          <div className="lg:hidden flex items-center">
             <button
               onClick={toggleMenu}
               className="inline-flex items-center justify-center p-2 rounded-md text-gray-700 hover:text-primary-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-primary-500"
@@ -176,8 +176,8 @@ const Navbar: React.FC = () => {
       </div>
 
       {/* Mobile menu */}
-      <div className={`md:hidden ${isOpen ? 'block' : 'hidden'}`}>
-        <div className="pt-2 pb-4 space-y-1 border-t border-gray-200 bg-white">
+      <div className={`lg:hidden ${isOpen ? 'block' : 'hidden'}`}>
+        <div className="container mx-auto px-2 pt-2 pb-4 space-y-1 border-t border-gray-200 bg-white">
           {mainNavigation.map((item) => (
             <div key={item.label}>
               <button


### PR DESCRIPTION
Minor navigation UI responsive fix:
Improve navigation breaking UI on `md` > `lg` screen size.

Before:
<img width="862" height="748" alt="image" src="https://github.com/user-attachments/assets/a733b7dc-5e2d-4cdc-90c3-0c89206c2e34" />

After:
<img width="957" height="392" alt="image" src="https://github.com/user-attachments/assets/940353ed-a9ba-448f-8393-08fc4b037d22" />
