### PR TITLE
fix(card): correct navigation tile link on Executive Departments section

### DIFF
--- a/src/pages/government/departments/index.tsx
+++ b/src/pages/government/departments/index.tsx
@@ -14,6 +14,7 @@ import { getDepartmentsSEOData } from '../../../utils/seo-data'
 
 interface Department {
   office_name: string
+  slug: string
   address?: string
   trunkline?: string
   website?: string
@@ -221,7 +222,7 @@ export default function DepartmentsIndex() {
             return (
               <Link
                 to={`/government/departments/${encodeURIComponent(
-                  dept.office_name
+                  dept.slug
                 )}`}
                 key={index}
                 className="block"


### PR DESCRIPTION
**Title:**
Fix: Resolve navigation issue on Executive Departments tile link

**Description:**
This pull request addresses a minor navigation bug identified on the Executive Departments page. When users clicked on the department tiles, the navigation did not function as expected. However, navigation via the sidebar links worked correctly.

**Related Issue:**
Closes [[#79](https://github.com/bettergovph/bettergov/issues/79)]

