### PR TITLE
fix: reverse timeline order to show newest events first

### DIFF
--- a/src/pages/philippines/history/index.tsx
+++ b/src/pages/philippines/history/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Clock, Flag, Crown, Star } from 'lucide-react';
+import { Clock, Flag, Crown, Scale } from 'lucide-react';
 import { Card, CardContent } from '../../../components/ui/Card';
 
 const PhilippinesHistory: React.FC = () => {
@@ -13,7 +13,7 @@ const PhilippinesHistory: React.FC = () => {
       image: '/assets/history/independence-modern-era.webp',
     },
     {
-      icon: <Star className='h-6 w-6' />,
+      icon: <Scale className='h-6 w-6' />,
       title: 'American Period',
       period: '1898-1946',
       description:

--- a/src/pages/philippines/history/index.tsx
+++ b/src/pages/philippines/history/index.tsx
@@ -1,67 +1,67 @@
-import React from "react";
-import { Clock, Flag, Crown, Scale, Star } from "lucide-react";
-import { Card, CardContent } from "../../../components/ui/Card";
+import React from 'react';
+import { Clock, Flag, Crown, Star } from 'lucide-react';
+import { Card, CardContent } from '../../../components/ui/Card';
 
 const PhilippinesHistory: React.FC = () => {
   const timelinePeriods = [
     {
-      icon: <Clock className="h-6 w-6" />,
-      title: "Pre-Colonial Period",
-      period: "Before 1521",
+      icon: <Flag className='h-6 w-6' />,
+      title: 'Independence and Modern Era',
+      period: '1946-Present',
       description:
-        "Indigenous peoples with advanced societies, trade networks, and rich cultures",
-      image: "/assets/history/pre-colonial-period.webp",
+        'Independent republic facing challenges and achievements in nation-building',
+      image: '/assets/history/independence-modern-era.webp',
     },
     {
-      icon: <Crown className="h-6 w-6" />,
-      title: "Spanish Colonial Era",
-      period: "1521-1898",
+      icon: <Star className='h-6 w-6' />,
+      title: 'American Period',
+      period: '1898-1946',
       description:
-        "Over 300 years of Spanish rule, introducing Christianity and colonial institutions",
-      image: "/assets/history/spanish-colonial-era.webp",
+        'American administration, introducing modern education and democratic institutions',
+      image: '/assets/history/american-period.webp',
     },
     {
-      icon: <Star className="h-6 w-6" />,
-      title: "American Period",
-      period: "1898-1946",
+      icon: <Crown className='h-6 w-6' />,
+      title: 'Spanish Colonial Era',
+      period: '1521-1898',
       description:
-        "American administration, introducing modern education and democratic institutions",
-      image: "/assets/history/american-period.webp",
+        'Over 300 years of Spanish rule, introducing Christianity and colonial institutions',
+      image: '/assets/history/spanish-colonial-era.webp',
     },
     {
-      icon: <Flag className="h-6 w-6" />,
-      title: "Independence and Modern Era",
-      period: "1946-Present",
+      icon: <Clock className='h-6 w-6' />,
+      title: 'Pre-Colonial Period',
+      period: 'Before 1521',
       description:
-        "Independent republic facing challenges and achievements in nation-building",
-      image: "/assets/history/independence-modern-era.webp",
+        'Indigenous peoples with advanced societies, trade networks, and rich cultures',
+      image: '/assets/history/pre-colonial-period.webp',
     },
   ];
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className='min-h-screen bg-gray-50'>
       {/* Hero Section */}
-      <div className="relative h-[60vh] overflow-hidden">
-        <div className="absolute inset-0">
+      <div className='relative h-[60vh] overflow-hidden'>
+        <div className='absolute inset-0'>
           <img
-            src="https://images.pexels.com/photos/19376770/pexels-photo-19376770/free-photo-of-women-dancing-in-red-traditional-clothing-in-festival.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2"
-            alt="Historical Philippines"
-            className="w-full h-full object-cover"
+            src='https://images.pexels.com/photos/19376770/pexels-photo-19376770/free-photo-of-women-dancing-in-red-traditional-clothing-in-festival.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2'
+            alt='Historical Philippines'
+            className='w-full h-full object-cover'
           />
-          <div className="absolute inset-0 bg-black/50" />
+          <div className='absolute inset-0 bg-black/50' />
         </div>
-        <div className="relative h-full flex items-center">
-          <div className="container mx-auto px-4">
-            <div className="max-w-3xl">
-              <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6">
+        <div className='relative h-full flex items-center'>
+          <div className='container mx-auto px-4'>
+            <div className='max-w-3xl'>
+              <h1 className='text-4xl md:text-5xl lg:text-6xl font-bold text-white mb-6'>
                 History of the Philippines
               </h1>
-              <p className="text-xl text-white/90 leading-relaxed">
+              <p className='text-xl text-white/90 leading-relaxed'>
                 Journey through time and discover the rich tapestry of events,
                 people, and movements that shaped the Philippine nation.
               </p>
-              <p className="text-xs">
-                <a href="https://www.pexels.com/photo/women-dancing-in-red-traditional-clothing-in-festival-19376770/">
+              <p className='text-xs'>
+                <a href='https://www.pexels.com/photo/women-dancing-in-red-traditional-clothing-in-festival-19376770/'>
                   Photo credit
                 </a>
               </p>
@@ -71,67 +71,78 @@ const PhilippinesHistory: React.FC = () => {
       </div>
 
       {/* Main Content */}
-      <div className="container mx-auto px-4 py-12">
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+      <div className='container mx-auto px-4 py-12'>
+        <div className='grid grid-cols-1 lg:grid-cols-3 gap-8'>
           {/* Timeline */}
-          <div className="lg:col-span-2">
-            <section className="mb-12">
-              <h2 className="text-3xl font-bold text-gray-900 mb-6">
+          <div className='lg:col-span-2'>
+            <section className='mb-12'>
+              <h2 className='text-3xl font-bold text-gray-900 mb-8'>
                 Historical Timeline
               </h2>
-              <div className="space-y-8">
-                {timelinePeriods.map((period, index) => (
-                  <Card key={index}>
-                    <CardContent className="p-6">
-                      <div className="flex items-start space-x-4">
-                        <div className="p-3 bg-primary-100 rounded-lg text-primary-600">
-                          {period.icon}
-                        </div>
-                        <div className="flex-1">
-                          <div className="flex items-center justify-between mb-2">
-                            <h3 className="text-xl font-semibold text-gray-900">
-                              {period.title}
-                            </h3>
-                            <span className="text-sm font-medium text-primary-600">
+              <div className='relative'>
+                {/* Timeline line */}
+                <div className='absolute left-8 top-0 bottom-0 w-0.5 bg-gray-300'></div>
+
+                <div className='space-y-12'>
+                  {timelinePeriods.map((period, index) => (
+                    <div key={index} className='relative flex items-start'>
+                      {/* Timeline node */}
+                      <div className='absolute left-0 w-16 h-16 bg-white rounded-full border-4 border-primary-500 shadow-lg flex items-center justify-center z-10'>
+                        <div className='text-primary-600'>{period.icon}</div>
+                      </div>
+
+                      {/* Content */}
+                      <div className='ml-24 flex-1'>
+                        <div className='bg-white rounded-lg shadow-md overflow-hidden hover:shadow-lg transition-shadow'>
+                          {/* Period header */}
+                          <div className='bg-primary-50 px-6 py-3 border-b border-primary-100'>
+                            <span className='text-lg font-bold text-primary-700'>
                               {period.period}
                             </span>
                           </div>
-                          <p className="text-gray-800 mb-4">
-                            {period.description}
-                          </p>
-                          <img
-                            src={period.image}
-                            alt={period.title}
-                            className="w-full max-h-64 object-cover object-center rounded-lg"
-                          />
+
+                          {/* Main content */}
+                          <div className='p-6'>
+                            <h3 className='text-2xl font-bold text-gray-900 mb-3'>
+                              {period.title}
+                            </h3>
+                            <p className='text-gray-700 mb-4 leading-relaxed'>
+                              {period.description}
+                            </p>
+                            <img
+                              src={period.image}
+                              alt={period.title}
+                              className='w-full h-48 object-cover rounded-lg'
+                            />
+                          </div>
                         </div>
                       </div>
-                    </CardContent>
-                  </Card>
-                ))}
+                    </div>
+                  ))}
+                </div>
               </div>
             </section>
 
             <section>
-              <h2 className="text-3xl font-bold text-gray-900 mb-6">
+              <h2 className='text-3xl font-bold text-gray-900 mb-6'>
                 Historical Overview
               </h2>
-              <div className="prose max-w-none">
-                <p className="text-gray-800 leading-relaxed mb-4">
-                  The Philippines' history spans thousands of years, beginning
-                  with the migration of Austronesian peoples. These early
-                  settlers developed sophisticated societies, trading with
+              <div className='prose max-w-none'>
+                <p className='text-gray-800 leading-relaxed mb-4'>
+                  The Philippines&apos; history spans thousands of years,
+                  beginning with the migration of Austronesian peoples. These
+                  early settlers developed sophisticated societies, trading with
                   various Asian civilizations and developing unique cultural
                   traditions.
                 </p>
-                <p className="text-gray-800 leading-relaxed mb-4">
+                <p className='text-gray-800 leading-relaxed mb-4'>
                   The arrival of Ferdinand Magellan in 1521 marked the beginning
                   of Spanish colonization, which would last for over three
                   centuries. This period saw the widespread adoption of
                   Christianity and the establishment of colonial institutions
                   that would significantly influence Filipino society.
                 </p>
-                <p className="text-gray-800 leading-relaxed">
+                <p className='text-gray-800 leading-relaxed'>
                   Following the Spanish-American War, the Philippines came under
                   American rule, leading to significant changes in education,
                   governance, and society. The country achieved independence in
@@ -143,39 +154,43 @@ const PhilippinesHistory: React.FC = () => {
           </div>
 
           {/* Sidebar */}
-          <div className="space-y-6">
+          <div className='space-y-6'>
             <Card>
-              <CardContent className="p-6">
-                <h3 className="text-xl font-semibold text-gray-900 mb-4">
+              <CardContent className='p-6'>
+                <h3 className='text-xl font-semibold text-gray-900 mb-4'>
                   Key Historical Figures
                 </h3>
-                <div className="space-y-4">
+                <div className='space-y-4'>
                   <div>
-                    <div className="font-medium text-gray-900">José Rizal</div>
-                    <div className="text-sm text-gray-800">
-                      National Hero, Writer, Reformist
+                    <div className='font-medium text-gray-900'>
+                      {'José Rizal'}
+                    </div>
+                    <div className='text-sm text-gray-800'>
+                      {'National Hero, Writer, Reformist'}
                     </div>
                   </div>
                   <div>
-                    <div className="font-medium text-gray-900">
-                      Andrés Bonifacio
+                    <div className='font-medium text-gray-900'>
+                      {'Andrés Bonifacio'}
                     </div>
-                    <div className="text-sm text-gray-800">
-                      Revolutionary Leader
+                    <div className='text-sm text-gray-800'>
+                      {'Revolutionary Leader'}
                     </div>
                   </div>
                   <div>
-                    <div className="font-medium text-gray-900">
-                      Emilio Aguinaldo
+                    <div className='font-medium text-gray-900'>
+                      {'Emilio Aguinaldo'}
                     </div>
-                    <div className="text-sm text-gray-800">First President</div>
+                    <div className='text-sm text-gray-800'>
+                      {'First President'}
+                    </div>
                   </div>
                   <div>
-                    <div className="font-medium text-gray-900">
-                      Corazon Aquino
+                    <div className='font-medium text-gray-900'>
+                      {'Corazon Aquino'}
                     </div>
-                    <div className="text-sm text-gray-800">
-                      Democracy Icon, Former President
+                    <div className='text-sm text-gray-800'>
+                      {'Democracy Icon, Former President'}
                     </div>
                   </div>
                 </div>
@@ -183,39 +198,39 @@ const PhilippinesHistory: React.FC = () => {
             </Card>
 
             <Card>
-              <CardContent className="p-6">
-                <h3 className="text-xl font-semibold text-gray-900 mb-4">
+              <CardContent className='p-6'>
+                <h3 className='text-xl font-semibold text-gray-900 mb-4'>
                   Important Dates
                 </h3>
-                <div className="space-y-3">
+                <div className='space-y-3'>
                   <div>
-                    <div className="text-sm font-medium text-gray-800">
-                      March 16, 1521
+                    <div className='text-sm font-medium text-gray-800'>
+                      {'March 16, 1521'}
                     </div>
-                    <div className="text-gray-900">Arrival of Magellan</div>
+                    <div className='text-gray-900'>{'Arrival of Magellan'}</div>
                   </div>
                   <div>
-                    <div className="text-sm font-medium text-gray-800">
-                      June 12, 1898
+                    <div className='text-sm font-medium text-gray-800'>
+                      {'June 12, 1898'}
                     </div>
-                    <div className="text-gray-900">
-                      Declaration of Independence
-                    </div>
-                  </div>
-                  <div>
-                    <div className="text-sm font-medium text-gray-800">
-                      July 4, 1946
-                    </div>
-                    <div className="text-gray-900">
-                      Recognition of Independence
+                    <div className='text-gray-900'>
+                      {'Declaration of Independence'}
                     </div>
                   </div>
                   <div>
-                    <div className="text-sm font-medium text-gray-800">
-                      February 25, 1986
+                    <div className='text-sm font-medium text-gray-800'>
+                      {'July 4, 1946'}
                     </div>
-                    <div className="text-gray-900">
-                      EDSA People Power Revolution
+                    <div className='text-gray-900'>
+                      {'Recognition of Independence'}
+                    </div>
+                  </div>
+                  <div>
+                    <div className='text-sm font-medium text-gray-800'>
+                      {'February 25, 1986'}
+                    </div>
+                    <div className='text-gray-900'>
+                      {'EDSA People Power Revolution'}
                     </div>
                   </div>
                 </div>
@@ -223,32 +238,32 @@ const PhilippinesHistory: React.FC = () => {
             </Card>
 
             <Card>
-              <CardContent className="p-6">
-                <h3 className="text-xl font-semibold text-gray-900 mb-4">
+              <CardContent className='p-6'>
+                <h3 className='text-xl font-semibold text-gray-900 mb-4'>
                   Related Links
                 </h3>
-                <nav className="space-y-2">
+                <nav className='space-y-2'>
                   <a
-                    href="/philippines/about"
-                    className="block px-4 py-2 text-gray-700 hover:bg-gray-50 rounded-md transition-colors"
+                    href='/philippines/about'
+                    className='block px-4 py-2 text-gray-700 hover:bg-gray-50 rounded-md transition-colors'
                   >
                     About
                   </a>
                   <a
-                    href="/philippines/culture"
-                    className="block px-4 py-2 text-gray-700 hover:bg-gray-50 rounded-md transition-colors"
+                    href='/philippines/culture'
+                    className='block px-4 py-2 text-gray-700 hover:bg-gray-50 rounded-md transition-colors'
                   >
                     Culture
                   </a>
                   <a
-                    href="/philippines/regions"
-                    className="block px-4 py-2 text-gray-700 hover:bg-gray-50 rounded-md transition-colors"
+                    href='/philippines/regions'
+                    className='block px-4 py-2 text-gray-700 hover:bg-gray-50 rounded-md transition-colors'
                   >
                     Regions
                   </a>
                   <a
-                    href="/philippines/tourism"
-                    className="block px-4 py-2 text-gray-700 hover:bg-gray-50 rounded-md transition-colors"
+                    href='/philippines/tourism'
+                    className='block px-4 py-2 text-gray-700 hover:bg-gray-50 rounded-md transition-colors'
                   >
                     Tourism
                   </a>


### PR DESCRIPTION
## Summary
- Reversed the timeline to show newest events first (starting with Independence Era) since that's how timelines typically work
- Made the timeline actually look like a timeline with visual elements

## Changes Made
- Flipped the order: Independence Era → American Period → Spanish Era → Pre-Colonial
- Added a vertical line connecting all timeline events
- Added circular nodes with icons for each time period
- Better visual cards with period badges showing the dates
- Fixed some linting issues (unused imports, quote consistency)

## Test Plan
- [x] Timeline shows newest first (1946-Present at the top)
- [x] Visual timeline elements display correctly
- [x] All historical information is still accurate
- [x] Page works on mobile
- [x] No broken links