### PR TITLE
fix: zoom controls not working

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Run ESLint
         run: npm run lint
 
+      - name: Check Prettier formatting
+        run: npx prettier --check .
+
   e2e_tests:
     name: Playwright Tests
     runs-on: ubuntu-latest

--- a/src/pages/philippines/map/index.tsx
+++ b/src/pages/philippines/map/index.tsx
@@ -1,7 +1,7 @@
-import React, { useState, useEffect, useCallback, useRef } from 'react'
-import { MapContainer, TileLayer, GeoJSON } from 'react-leaflet'
-import L, { LatLngExpression, GeoJSON as LeafletGeoJSON, Layer } from 'leaflet'
-import 'leaflet/dist/leaflet.css'
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import { MapContainer, TileLayer, GeoJSON } from 'react-leaflet';
+import L, { LatLngExpression, GeoJSON as LeafletGeoJSON, Layer } from 'leaflet';
+import 'leaflet/dist/leaflet.css';
 import {
   Search,
   MapPin,
@@ -11,82 +11,82 @@ import {
   FileText,
   ZoomIn,
   ZoomOut,
-} from 'lucide-react'
-import Button from '../../../components/ui/Button'
-import { ScrollArea } from '../../../components/ui/ScrollArea'
-import philippinesRegionsData from '../../../data/philippines-regions.json' // Renamed for clarity
+} from 'lucide-react';
+import Button from '../../../components/ui/Button';
+import { ScrollArea } from '../../../components/ui/ScrollArea';
+import philippinesRegionsData from '../../../data/philippines-regions.json'; // Renamed for clarity
 
 // Define types for region data and GeoJSON properties
 interface RegionData {
-  id: string
-  name: string
-  description?: string
-  population?: string
-  capital?: string
-  area?: string
-  provinces?: string[]
-  wikipedia?: string
-  loading?: boolean
+  id: string;
+  name: string;
+  description?: string;
+  population?: string;
+  capital?: string;
+  area?: string;
+  provinces?: string[];
+  wikipedia?: string;
+  loading?: boolean;
 }
 
 interface RegionProperties {
-  name: string // Region name from GeoJSON
-  capital?: string
-  population?: string
-  provinces?: string[]
+  name: string; // Region name from GeoJSON
+  capital?: string;
+  population?: string;
+  provinces?: string[];
   // Add other properties from your GeoJSON if needed
 }
 
 // Wikipedia data cache
-const wikipediaCache = new Map<string, any>()
+const wikipediaCache = new Map<string, any>();
 
 const PhilippinesMap: React.FC = () => {
-  const [selectedRegion, setSelectedRegion] = useState<RegionData | null>(null)
+  const [selectedRegion, setSelectedRegion] = useState<RegionData | null>(null);
   const [hoveredRegionName, setHoveredRegionName] = useState<string | null>(
     null
-  )
-  const [searchQuery, setSearchQuery] = useState('')
+  );
+  const [searchQuery, setSearchQuery] = useState('');
   // GeoJSON data expects FeatureCollection structure
   const [mapData] = useState<GeoJSON.FeatureCollection<any, RegionProperties>>(
     philippinesRegionsData as GeoJSON.FeatureCollection<any, RegionProperties>
-  )
-  const [isLoadingDetails, setIsLoadingDetails] = useState(false)
-  const mapRef = useRef<L.Map>(null)
-  const geoJsonLayerRef = useRef<LeafletGeoJSON | null>(null)
+  );
+  const [isLoadingDetails, setIsLoadingDetails] = useState(false);
+  const mapRef = useRef<L.Map>(null);
+  const geoJsonLayerRef = useRef<LeafletGeoJSON | null>(null);
 
-  const initialCenter: LatLngExpression = [12.8797, 121.774] // Philippines center
-  const initialZoom = 6
+  const initialCenter: LatLngExpression = [12.8797, 121.774]; // Philippines center
+  const initialZoom = 6;
 
   // Fetch Wikipedia data
   const fetchWikipediaData = useCallback(async (regionName: string) => {
     if (wikipediaCache.has(regionName)) {
-      return wikipediaCache.get(regionName)
+      return wikipediaCache.get(regionName);
     }
-    setIsLoadingDetails(true)
+    setIsLoadingDetails(true);
     try {
       const response = await fetch(
         `https://en.wikipedia.org/api/rest_v1/page/summary/${encodeURIComponent(
           regionName + ', Philippines'
         )}`
-      )
-      if (!response.ok) throw new Error('Wikipedia data not found')
-      const data = await response.json()
-      wikipediaCache.set(regionName, data)
-      return data
+      );
+      if (!response.ok) throw new Error('Wikipedia data not found');
+      const data = await response.json();
+      wikipediaCache.set(regionName, data);
+      return data;
     } catch (err) {
-      console.error('Error fetching Wikipedia data:', err)
-      return null
+      console.error('Error fetching Wikipedia data:', err);
+      return null;
     } finally {
-      setIsLoadingDetails(false)
+      setIsLoadingDetails(false);
     }
-  }, [])
+  }, []);
 
   // Handle region click
   const onRegionClick = useCallback(
     async (feature: GeoJSON.Feature<any, RegionProperties>) => {
-      if (!feature.properties) return
-      const props = feature.properties
-      const regionName = props.name
+      if (!feature.properties) return;
+      const props = feature.properties;
+      const regionName = props.name;
 
       const regionDetails: RegionData = {
         id: regionName,
@@ -95,36 +95,36 @@ const PhilippinesMap: React.FC = () => {
         // population: props.population,
         // provinces: props.provinces,
         loading: true,
-      }
-      setSelectedRegion(regionDetails)
+      };
+      setSelectedRegion(regionDetails);
 
-      const wikiData = await fetchWikipediaData(regionName)
-      setSelectedRegion((prev) => ({
+      const wikiData = await fetchWikipediaData(regionName);
+      setSelectedRegion(prev => ({
         ...prev!,
         description: wikiData?.extract || 'No description available.',
         wikipedia: wikiData?.content_urls?.desktop?.page,
         loading: false,
-      }))
+      }));
     },
     [fetchWikipediaData]
-  )
+  );
 
   const getRegionName = (
     feature: GeoJSON.Feature<any, RegionProperties>
   ): string => {
-    const props = feature.properties
-    return props?.name || ''
-  }
+    const props = feature.properties;
+    return props?.name || '';
+  };
 
   // Style for GeoJSON features
   const regionStyle = (feature?: GeoJSON.Feature<any, RegionProperties>) => {
-    if (!feature) return {}
-    const regionName = getRegionName(feature)
-    const isSelected = selectedRegion?.id === regionName
-    const isHovered = hoveredRegionName === regionName
+    if (!feature) return {};
+    const regionName = getRegionName(feature);
+    const isSelected = selectedRegion?.id === regionName;
+    const isHovered = hoveredRegionName === regionName;
     const isFilteredOut =
       searchQuery &&
-      !regionName.toLowerCase().includes(searchQuery.toLowerCase())
+      !regionName.toLowerCase().includes(searchQuery.toLowerCase());
 
     return {
       fillColor: isSelected
@@ -138,8 +138,8 @@ const PhilippinesMap: React.FC = () => {
       opacity: 1,
       color: isSelected || isHovered ? '#4C1D95' : '#A78BFA',
       fillOpacity: isFilteredOut ? 0.3 : 0.7,
-    }
-  }
+    };
+  };
 
   // Event handlers for each feature
   const onEachFeature = (
@@ -148,77 +148,77 @@ const PhilippinesMap: React.FC = () => {
   ) => {
     layer.on({
       click: () => onRegionClick(feature),
-      mouseover: (e) => {
-        setHoveredRegionName(getRegionName(feature))
-        e.target.setStyle(regionStyle(feature)) // Re-apply style with hover state
-        e.target.bringToFront()
+      mouseover: e => {
+        setHoveredRegionName(getRegionName(feature));
+        e.target.setStyle(regionStyle(feature)); // Re-apply style with hover state
+        e.target.bringToFront();
       },
-      mouseout: (e) => {
-        setHoveredRegionName(null)
+      mouseout: e => {
+        setHoveredRegionName(null);
         // Reset to default style or selected style if it's the selected region
         if (geoJsonLayerRef.current) {
-          geoJsonLayerRef.current.resetStyle(e.target)
+          geoJsonLayerRef.current.resetStyle(e.target);
         }
       },
-    })
-  }
+    });
+  };
 
   // Filtered GeoJSON data based on search query
   const filteredMapData: GeoJSON.FeatureCollection<any, RegionProperties> = {
     ...mapData,
-    features: mapData.features.filter((feature) => {
-      if (!searchQuery) return true
-      const name = getRegionName(feature)
-      return name.toLowerCase().includes(searchQuery.toLowerCase())
+    features: mapData.features.filter(feature => {
+      if (!searchQuery) return true;
+      const name = getRegionName(feature);
+      return name.toLowerCase().includes(searchQuery.toLowerCase());
     }),
-  }
+  };
 
   // Effect to update GeoJSON layer when search query changes (to re-apply styles for filtered out items)
   useEffect(() => {
     if (geoJsonLayerRef.current) {
-      geoJsonLayerRef.current.clearLayers()
-      geoJsonLayerRef.current.addData(mapData) // Add all data, styling will handle filter appearance
+      geoJsonLayerRef.current.clearLayers();
+      geoJsonLayerRef.current.addData(mapData); // Add all data, styling will handle filter appearance
     }
-  }, [searchQuery, mapData])
+  }, [searchQuery, mapData]);
 
-  const handleZoomIn = () => mapRef.current?.zoomIn()
-  const handleZoomOut = () => mapRef.current?.zoomOut()
+  const handleZoomIn = () => mapRef.current?.zoomIn();
+  const handleZoomOut = () => mapRef.current?.zoomOut();
 
   return (
-    <div className="flex h-screen bg-gray-50">
+    <div className='flex h-screen bg-gray-50'>
       {/* Map Section */}
-      <div className="flex-1 relative">
+      <div className='flex-1 relative'>
         {/* Search Bar */}
-        <div className="absolute top-4 left-4 right-4 z-[1000] max-w-md">
-          <div className="relative">
-            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 h-5 w-5" />
+        <div className='absolute top-4 left-4 right-4 z-[1000] max-w-md'>
+          <div className='relative'>
+            <Search className='absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 h-5 w-5' />
             <input
-              type="text"
-              placeholder="Search regions..."
+              type='text'
+              placeholder='Search regions...'
               value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              className="w-full pl-10 pr-4 py-2 bg-white border border-gray-200 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent"
+              onChange={e => setSearchQuery(e.target.value)}
+              className='w-full pl-10 pr-4 py-2 bg-white border border-gray-200 rounded-lg shadow-sm focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent'
             />
           </div>
         </div>
 
         {/* Zoom Controls - Leaflet has its own, but we can add custom ones */}
-        <div className="absolute top-20 right-4 z-10 flex flex-col gap-2">
+        <div className='absolute top-20 right-4 z-10 flex flex-col gap-2'>
           <Button
-            variant="primary"
-            size="sm"
+            variant='primary'
+            size='sm'
             onClick={handleZoomIn}
-            aria-label="Zoom in"
+            aria-label='Zoom in'
           >
-            <ZoomIn className="h-4 w-4" />
+            <ZoomIn className='h-4 w-4' />
           </Button>
           <Button
-            variant="primary"
-            size="sm"
+            variant='primary'
+            size='sm'
             onClick={handleZoomOut}
-            aria-label="Zoom out"
+            aria-label='Zoom out'
           >
-            <ZoomOut className="h-4 w-4" />
+            <ZoomOut className='h-4 w-4' />
           </Button>
         </div>
 
@@ -238,11 +238,11 @@ const PhilippinesMap: React.FC = () => {
           zoom={initialZoom}
           style={{ height: '100%', width: '100%' }}
           // whenCreated={(mapInstance) => (mapRef.current = mapInstance)}
-          className="z-0"
+          className='z-0'
         >
           <TileLayer
             attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-            url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+            url='https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png'
           />
           {mapData && mapData.features && (
             <GeoJSON
@@ -257,8 +257,8 @@ const PhilippinesMap: React.FC = () => {
 
         {/* Hover Tooltip - Can be implemented differently with Leaflet, e.g., L.tooltip */}
         {hoveredRegionName && (
-          <div className="absolute bottom-4 left-4 bg-white px-4 py-2 rounded-lg shadow-lg z-[1000]">
-            <p className="text-sm font-medium text-gray-800">
+          <div className='absolute bottom-4 left-4 bg-white px-4 py-2 rounded-lg shadow-lg z-[1000]'>
+            <p className='text-sm font-medium text-gray-800'>
               {hoveredRegionName}
             </p>
           </div>
@@ -266,76 +266,78 @@ const PhilippinesMap: React.FC = () => {
       </div>
 
       {/* Details Panel */}
-      <div
-        className={`absolute right-0 top-40 h-full w-[400px] bg-white shadow-xl transition-transform duration-300 z-[1001] ${selectedRegion ? 'translate-x-0' : 'translate-x-full'
+
+      {selectedRegion && (
+        <div
+          className={`absolute right-0 top-40 h-full w-[400px] bg-white shadow-xl transition-transform duration-300 z-[1001] ${
+            selectedRegion ? 'translate-x-0' : 'translate-x-full'
           }`}
-      >
-        {selectedRegion && (
-          <div className="h-full flex flex-col">
-            <div className="p-6 border-b border-gray-200">
-              <div className="flex items-start justify-between">
+        >
+          <div className='h-full flex flex-col'>
+            <div className='p-6 border-b border-gray-200'>
+              <div className='flex items-start justify-between'>
                 <div>
-                  <h2 className="text-2xl font-bold text-gray-900">
+                  <h2 className='text-2xl font-bold text-gray-900'>
                     {selectedRegion.name}
                   </h2>
-                  <p className="text-sm text-gray-800 mt-1">
+                  <p className='text-sm text-gray-800 mt-1'>
                     Philippine Region
                   </p>
                 </div>
                 <button
                   onClick={() => setSelectedRegion(null)}
-                  className="text-gray-400 hover:text-gray-800"
+                  className='text-gray-400 hover:text-gray-800'
                 >
                   <svg
-                    className="h-6 w-6"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
+                    className='h-6 w-6'
+                    fill='none'
+                    stroke='currentColor'
+                    viewBox='0 0 24 24'
                   >
                     <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
+                      strokeLinecap='round'
+                      strokeLinejoin='round'
                       strokeWidth={2}
-                      d="M6 18L18 6M6 6l12 12"
+                      d='M6 18L18 6M6 6l12 12'
                     />
                   </svg>
                 </button>
               </div>
             </div>
-            <ScrollArea className="flex-1">
-              <div className="p-6 space-y-6">
+            <ScrollArea className='flex-1'>
+              <div className='p-6 space-y-6'>
                 {selectedRegion.loading || isLoadingDetails ? (
-                  <div className="flex items-center justify-center py-12">
-                    <Loader2 className="h-8 w-8 animate-spin text-purple-600" />
+                  <div className='flex items-center justify-center py-12'>
+                    <Loader2 className='h-8 w-8 animate-spin text-purple-600' />
                   </div>
                 ) : (
                   <>
                     <div>
-                      <h3 className="text-lg font-semibold text-gray-900 mb-2">
+                      <h3 className='text-lg font-semibold text-gray-900 mb-2'>
                         Overview
                       </h3>
-                      <p className="text-gray-800 leading-relaxed">
+                      <p className='text-gray-800 leading-relaxed'>
                         {selectedRegion.description}
                       </p>
                     </div>
                     <div>
-                      <h3 className="text-lg font-semibold text-gray-900 mb-3">
+                      <h3 className='text-lg font-semibold text-gray-900 mb-3'>
                         Quick Facts
                       </h3>
-                      <div className="grid grid-cols-1 gap-4">
+                      <div className='grid grid-cols-1 gap-4'>
                         <InfoItem
                           icon={<Building2 />}
-                          label="Capital"
+                          label='Capital'
                           value={selectedRegion.capital}
                         />
                         <InfoItem
                           icon={<Users />}
-                          label="Population"
+                          label='Population'
                           value={selectedRegion.population}
                         />
                         <InfoItem
                           icon={<MapPin />}
-                          label="Area"
+                          label='Area'
                           value={selectedRegion.area}
                         />
                       </div>
@@ -343,14 +345,14 @@ const PhilippinesMap: React.FC = () => {
                     {selectedRegion.provinces &&
                       selectedRegion.provinces.length > 0 && (
                         <div>
-                          <h3 className="text-lg font-semibold text-gray-900 mb-3">
+                          <h3 className='text-lg font-semibold text-gray-900 mb-3'>
                             Provinces
                           </h3>
-                          <div className="flex flex-wrap gap-2">
-                            {selectedRegion.provinces.map((province) => (
+                          <div className='flex flex-wrap gap-2'>
+                            {selectedRegion.provinces.map(province => (
                               <span
                                 key={province}
-                                className="px-3 py-1 bg-purple-100 text-purple-700 rounded-full text-sm"
+                                className='px-3 py-1 bg-purple-100 text-purple-700 rounded-full text-sm'
                               >
                                 {province}
                               </span>
@@ -360,17 +362,17 @@ const PhilippinesMap: React.FC = () => {
                       )}
                     {selectedRegion.wikipedia && (
                       <div>
-                        <h3 className="text-lg font-semibold text-gray-900 mb-3">
+                        <h3 className='text-lg font-semibold text-gray-900 mb-3'>
                           Learn More
                         </h3>
                         <a
                           href={selectedRegion.wikipedia}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="flex items-center gap-2 text-purple-600 hover:text-purple-700"
+                          target='_blank'
+                          rel='noopener noreferrer'
+                          className='flex items-center gap-2 text-purple-600 hover:text-purple-700'
                         >
-                          <FileText className="h-4 w-4" />
-                          <span className="text-sm">Wikipedia Article</span>
+                          <FileText className='h-4 w-4' />
+                          <span className='text-sm'>Wikipedia Article</span>
                         </a>
                       </div>
                     )}
@@ -379,28 +381,28 @@ const PhilippinesMap: React.FC = () => {
               </div>
             </ScrollArea>
           </div>
-        )}
-      </div>
+        </div>
+      )}
     </div>
-  )
-}
+  );
+};
 
 // Helper component for info items in details panel
 interface InfoItemProps {
-  icon: React.ReactNode
-  label: string
-  value?: string
+  icon: React.ReactNode;
+  label: string;
+  value?: string;
 }
 const InfoItem: React.FC<InfoItemProps> = ({ icon, label, value }) => (
-  <div className="flex items-start gap-3">
+  <div className='flex items-start gap-3'>
     {React.cloneElement(icon as React.ReactElement, {
       className: 'h-5 w-5 text-purple-600 mt-0.5',
     })}
     <div>
-      <p className="text-sm font-medium text-gray-900">{label}</p>
-      <p className="text-sm text-gray-800">{value || 'N/A'}</p>
+      <p className='text-sm font-medium text-gray-900'>{label}</p>
+      <p className='text-sm text-gray-800'>{value || 'N/A'}</p>
     </div>
   </div>
-)
+);
 
-export default PhilippinesMap
+export default PhilippinesMap;

--- a/src/pages/philippines/map/index.tsx
+++ b/src/pages/philippines/map/index.tsx
@@ -268,12 +268,12 @@ const PhilippinesMap: React.FC = () => {
       </div>
 
       {/* Details Panel */}
-      <div
-        className={`absolute right-0 top-40 h-full w-[400px] bg-white shadow-xl transition-transform duration-300 z-[1001] ${
-          selectedRegion ? 'translate-x-0' : 'translate-x-full'
-        }`}
-      >
-        {selectedRegion && (
+      {selectedRegion && (
+        <div
+          className={`absolute right-0 top-40 h-full w-[400px] bg-white shadow-xl transition-transform duration-300 z-[1001] ${
+            selectedRegion ? 'translate-x-0' : 'translate-x-full'
+          }`}
+        >
           <div className='h-full flex flex-col'>
             <div className='p-6 border-b border-gray-200'>
               <div className='flex items-start justify-between'>
@@ -382,8 +382,8 @@ const PhilippinesMap: React.FC = () => {
               </div>
             </ScrollArea>
           </div>
-        )}
-      </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/pages/philippines/map/index.tsx
+++ b/src/pages/philippines/map/index.tsx
@@ -236,6 +236,8 @@ const PhilippinesMap: React.FC = () => {
         <MapContainer
           center={initialCenter}
           zoom={initialZoom}
+          ref={mapRef}
+          zoomControl={false}
           style={{ height: '100%', width: '100%' }}
           // whenCreated={(mapInstance) => (mapRef.current = mapInstance)}
           className='z-0'
@@ -266,13 +268,12 @@ const PhilippinesMap: React.FC = () => {
       </div>
 
       {/* Details Panel */}
-
-      {selectedRegion && (
-        <div
-          className={`absolute right-0 top-40 h-full w-[400px] bg-white shadow-xl transition-transform duration-300 z-[1001] ${
-            selectedRegion ? 'translate-x-0' : 'translate-x-full'
-          }`}
-        >
+      <div
+        className={`absolute right-0 top-40 h-full w-[400px] bg-white shadow-xl transition-transform duration-300 z-[1001] ${
+          selectedRegion ? 'translate-x-0' : 'translate-x-full'
+        }`}
+      >
+        {selectedRegion && (
           <div className='h-full flex flex-col'>
             <div className='p-6 border-b border-gray-200'>
               <div className='flex items-start justify-between'>
@@ -381,8 +382,8 @@ const PhilippinesMap: React.FC = () => {
               </div>
             </ScrollArea>
           </div>
-        </div>
-      )}
+        )}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
**Description:**
- This PR addresses an issue with the map’s zoom functionality:
- React Leaflet’s default zoom control was removed to avoid duplication.

**Issue:**
<img width="482" height="95" alt="map-zoom-issue" src="https://github.com/user-attachments/assets/3842dd8e-661c-4db4-b580-a61034075352" />
<img width="92" height="139" alt="image" src="https://github.com/user-attachments/assets/6dba6f7a-11b2-4b91-a437-d44280fcf390" />

- The search bar overlapped with the zoom controls.
- Both the default Leaflet zoom controls and custom zoom controls were displayed.
- The custom zoom buttons were not functional.

**Fix:**
<img width="492" height="86" alt="map-zoom-fix" src="https://github.com/user-attachments/assets/e09a3483-c29f-45cb-9ffe-53769eb64990" />

- Removed React Leaflet’s native zoom controls.
- Fixed the custom zoom controls to properly zoom the map.
- Improved UI layout so the search bar no longer overlaps with controls.

Notes:

- This PR only affects the map UI and zoom behavior.
- No business logic was modified.
- This fix happen only in the map page.