### PR TITLE
Remove unnecessary slug text

### DIFF
--- a/src/pages/government/constitutional/index.tsx
+++ b/src/pages/government/constitutional/index.tsx
@@ -54,6 +54,7 @@ function OfficeDetailSection({
   // Skip these keys as they're displayed in the header
   const skipKeys = [
     'name',
+    'slug',
     'office_type',
     'description',
     'address',


### PR DESCRIPTION
The current implementation shows the slug, which is unnecessary

<img width="1298" height="763" alt="image" src="https://github.com/user-attachments/assets/9e7e5d6c-42a2-42fd-bd1d-ec1a9136b1d2" />


Just removing it here so its cleaner

<img width="1288" height="730" alt="image" src="https://github.com/user-attachments/assets/e19e6609-cc16-406f-9dd4-1d240164d046" />

