### PR TITLE
style: update responsiveness of government departments section

### DIFF
--- a/src/pages/government/GovernmentPageContainer.tsx
+++ b/src/pages/government/GovernmentPageContainer.tsx
@@ -1,10 +1,10 @@
-import { ReactNode, useState } from 'react'
-import { Menu, X } from 'lucide-react'
+import { ReactNode, useState } from 'react';
+import { Menu, X } from 'lucide-react';
 
 interface GovernmentPageContainerProps {
-  children: ReactNode
-  sidebar?: ReactNode
-  className?: string
+  children: ReactNode;
+  sidebar?: ReactNode;
+  className?: string;
 }
 
 export default function GovernmentPageContainer({
@@ -12,29 +12,29 @@ export default function GovernmentPageContainer({
   sidebar,
   className = '',
 }: GovernmentPageContainerProps) {
-  const [sidebarOpen, setSidebarOpen] = useState(false)
+  const [sidebarOpen, setSidebarOpen] = useState(false);
 
   return (
-    <div className={`min-h-screen bg-gray-50 ${className}`}>
-      <div className="container mx-auto px-4 py-6 md:py-8">
+    <div className={`min-h-screen md:bg-gray-50 ${className}`}>
+      <div className='container mx-auto sm:px-4 py-6 md:py-8'>
         {/* Mobile Sidebar Toggle */}
         {sidebar && (
-          <div className="md:hidden mb-4">
+          <div className='md:hidden mb-4'>
             <button
               onClick={() => setSidebarOpen(!sidebarOpen)}
-              className="flex items-center justify-between w-full px-4 py-3 bg-white rounded-lg shadow-sm text-gray-900 font-medium border"
+              className='flex items-center justify-between w-full px-4 py-3 bg-white rounded-lg shadow-sm text-gray-900 font-medium border'
             >
               <span>Menu</span>
               {sidebarOpen ? (
-                <X className="h-5 w-5 text-gray-800" />
+                <X className='h-5 w-5 text-gray-800' />
               ) : (
-                <Menu className="h-5 w-5 text-gray-800" />
+                <Menu className='h-5 w-5 text-gray-800' />
               )}
             </button>
           </div>
         )}
 
-        <div className="flex flex-col md:flex-row md:gap-8">
+        <div className='flex flex-col md:flex-row md:gap-8'>
           {sidebar && (
             <aside
               className={`${
@@ -44,22 +44,22 @@ export default function GovernmentPageContainer({
               {sidebar}
             </aside>
           )}
-          <main className="flex-1 min-w-0">
-            <div className="bg-white rounded-lg border shadow-sm p-4 md:p-8">
+          <main className='flex-1 min-w-0'>
+            <div className='bg-white rounded-lg border shadow-sm p-4 md:p-8'>
               {children}
             </div>
           </main>
         </div>
       </div>
     </div>
-  )
+  );
 }
 
 interface GovernmentPageHeaderProps {
-  title: string
-  subtitle?: string
-  actions?: ReactNode
-  className?: string
+  title: string;
+  subtitle?: string;
+  actions?: ReactNode;
+  className?: string;
 }
 
 export function GovernmentPageHeader({
@@ -73,21 +73,21 @@ export function GovernmentPageHeader({
       className={`flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-6 md:mb-8 ${className}`}
     >
       <div>
-        <h1 className="text-2xl md:text-3xl font-bold text-gray-900 mb-2">
+        <h1 className='text-2xl md:text-3xl font-bold text-gray-900 mb-2'>
           {title}
         </h1>
         {subtitle && (
-          <p className="text-sm md:text-base text-gray-800">{subtitle}</p>
+          <p className='text-sm md:text-base text-gray-800'>{subtitle}</p>
         )}
       </div>
-      {actions && <div className="flex-shrink-0">{actions}</div>}
+      {actions && <div className='flex-shrink-0'>{actions}</div>}
     </div>
-  )
+  );
 }
 
 interface GovernmentIndexPageContainerProps {
-  children: ReactNode
-  className?: string
+  children: ReactNode;
+  className?: string;
 }
 
 export function GovernmentIndexPageContainer({
@@ -96,11 +96,11 @@ export function GovernmentIndexPageContainer({
 }: GovernmentIndexPageContainerProps) {
   return (
     <div className={`min-h-screen bg-gray-50 ${className}`}>
-      <div className="container mx-auto px-4 py-6 md:py-8">
-        <div className="bg-white rounded-lg border shadow-sm p-4 md:p-8">
+      <div className='container mx-auto px-4 py-6 md:py-8'>
+        <div className='bg-white rounded-lg border shadow-sm p-4 md:p-8'>
           {children}
         </div>
       </div>
     </div>
-  )
+  );
 }

--- a/src/pages/government/departments/index.tsx
+++ b/src/pages/government/departments/index.tsx
@@ -157,7 +157,14 @@ function DepartmentDetailSection({
   }
 
   // Skip these keys as they're displayed in the header
-  const skipKeys = ['office_name', 'address', 'trunkline', 'website', 'email', 'slug'];
+  const skipKeys = [
+    'office_name',
+    'address',
+    'trunkline',
+    'website',
+    'email',
+    'slug',
+  ];
 
   const entries = Object.entries(data).filter(
     ([key]) => !skipKeys.includes(key)
@@ -208,7 +215,7 @@ export default function DepartmentsIndex() {
   return (
     <>
       <SEO {...seoData} />
-      <div className='space-y-8'>
+      <div className='space-y-8 @container'>
         <div>
           <h1 className='text-3xl font-bold text-gray-900 mb-2'>
             Government Departments
@@ -220,7 +227,7 @@ export default function DepartmentsIndex() {
           </p>
         </div>
 
-        <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6'>
+        <div className='grid grid-cols-1 @lg:grid-cols-2 @2xl:grid-cols-3 gap-6'>
           {departments.map((dept, index) => {
             // Extract department name without "DEPARTMENT OF" prefix for cleaner display
             const deptName = dept.office_name.replace('DEPARTMENT OF ', '');


### PR DESCRIPTION
- media query will be based on container and not the page
- remove grouping background in mobile view.

### Before
<img width="1309" height="1259" alt="image" src="https://github.com/user-attachments/assets/3ce65009-618a-4920-be24-d78d400768d5" />

### After
<img width="1333" height="1262" alt="image" src="https://github.com/user-attachments/assets/8d0774f6-3ac3-4ea1-858c-aaf9e950b583" />


P.S. 
unfortunately, precommit hook add lot of changes.
