### PR TITLE
fix: improve mobile responsiveness of flood control statistics cards

### DIFF
--- a/src/pages/flood-control-projects/tab.tsx
+++ b/src/pages/flood-control-projects/tab.tsx
@@ -7,51 +7,53 @@ export default function FloodControlProjectsTab({
   selectedTab: string;
 }) {
   return (
-    <div className='flex border-b border-gray-200 mb-6'>
-      <Link
-        to='/flood-control-projects'
-        className={`px-4 py-2 border-b-2 ${
-          selectedTab === 'index'
-            ? 'border-blue-500'
-            : 'text-gray-800 hover:text-blue-600'
-        } font-medium flex items-center`}
-      >
-        <BarChart3 className='w-4 h-4 mr-2' />
-        Visual
-      </Link>
-      <Link
-        to='/flood-control-projects/table'
-        className={`px-4 py-2 border-b-2 ${
-          selectedTab === 'table'
-            ? 'border-blue-500'
-            : 'text-gray-800 hover:text-blue-600'
-        } font-medium flex items-center`}
-      >
-        <Table className='w-4 h-4 mr-2' />
-        Table
-      </Link>
-      <Link
-        to='/flood-control-projects/contractors'
-        className={`px-4 py-2 border-b-2 ${
-          selectedTab === 'contractors'
-            ? 'border-blue-500'
-            : 'text-gray-800 hover:text-blue-600'
-        } font-medium flex items-center`}
-      >
-        <Users className='w-4 h-4 mr-2' />
-        Contractors
-      </Link>
-      <Link
-        to='/flood-control-projects/map'
-        className={`px-4 py-2 border-b-2 ${
-          selectedTab === 'map'
-            ? 'border-blue-500'
-            : 'text-gray-800 hover:text-blue-600'
-        } font-medium flex items-center`}
-      >
-        <Map className='w-4 h-4 mr-2' />
-        Map
-      </Link>
+    <div className='border-b border-gray-200 mb-6 overflow-x-auto'>
+      <div className='flex min-w-max'>
+        <Link
+          to='/flood-control-projects'
+          className={`px-3 sm:px-4 py-2 border-b-2 ${
+            selectedTab === 'index'
+              ? 'border-blue-500'
+              : 'text-gray-800 hover:text-blue-600'
+          } font-medium flex items-center whitespace-nowrap`}
+        >
+          <BarChart3 className='w-4 h-4 mr-1.5 sm:mr-2' />
+          Visual
+        </Link>
+        <Link
+          to='/flood-control-projects/table'
+          className={`px-3 sm:px-4 py-2 border-b-2 ${
+            selectedTab === 'table'
+              ? 'border-blue-500'
+              : 'text-gray-800 hover:text-blue-600'
+          } font-medium flex items-center whitespace-nowrap`}
+        >
+          <Table className='w-4 h-4 mr-1.5 sm:mr-2' />
+          Table
+        </Link>
+        <Link
+          to='/flood-control-projects/contractors'
+          className={`px-3 sm:px-4 py-2 border-b-2 ${
+            selectedTab === 'contractors'
+              ? 'border-blue-500'
+              : 'text-gray-800 hover:text-blue-600'
+          } font-medium flex items-center whitespace-nowrap`}
+        >
+          <Users className='w-4 h-4 mr-1.5 sm:mr-2' />
+          Contractors
+        </Link>
+        <Link
+          to='/flood-control-projects/map'
+          className={`px-3 sm:px-4 py-2 border-b-2 ${
+            selectedTab === 'map'
+              ? 'border-blue-500'
+              : 'text-gray-800 hover:text-blue-600'
+          } font-medium flex items-center whitespace-nowrap`}
+        >
+          <Map className='w-4 h-4 mr-1.5 sm:mr-2' />
+          Map
+        </Link>
+      </div>
     </div>
   );
 }

--- a/src/pages/flood-control-projects/tab.tsx
+++ b/src/pages/flood-control-projects/tab.tsx
@@ -1,5 +1,6 @@
 import { BarChart3, Table, Map, Users } from 'lucide-react';
 import { Link } from 'react-router-dom';
+import { cn } from '../../lib/utils';
 
 export default function FloodControlProjectsTab({
   selectedTab = 'index',
@@ -11,44 +12,48 @@ export default function FloodControlProjectsTab({
       <div className='flex min-w-max'>
         <Link
           to='/flood-control-projects'
-          className={`px-3 sm:px-4 py-2 border-b-2 ${
+          className={cn(
+            'px-3 sm:px-4 py-2 border-b-2 font-medium flex items-center whitespace-nowrap',
             selectedTab === 'index'
               ? 'border-blue-500'
               : 'text-gray-800 hover:text-blue-600'
-          } font-medium flex items-center whitespace-nowrap`}
+          )}
         >
           <BarChart3 className='w-4 h-4 mr-1.5 sm:mr-2' />
           Visual
         </Link>
         <Link
           to='/flood-control-projects/table'
-          className={`px-3 sm:px-4 py-2 border-b-2 ${
+          className={cn(
+            'px-3 sm:px-4 py-2 border-b-2 font-medium flex items-center whitespace-nowrap',
             selectedTab === 'table'
               ? 'border-blue-500'
               : 'text-gray-800 hover:text-blue-600'
-          } font-medium flex items-center whitespace-nowrap`}
+          )}
         >
           <Table className='w-4 h-4 mr-1.5 sm:mr-2' />
           Table
         </Link>
         <Link
           to='/flood-control-projects/contractors'
-          className={`px-3 sm:px-4 py-2 border-b-2 ${
+          className={cn(
+            'px-3 sm:px-4 py-2 border-b-2 font-medium flex items-center whitespace-nowrap',
             selectedTab === 'contractors'
               ? 'border-blue-500'
               : 'text-gray-800 hover:text-blue-600'
-          } font-medium flex items-center whitespace-nowrap`}
+          )}
         >
           <Users className='w-4 h-4 mr-1.5 sm:mr-2' />
           Contractors
         </Link>
         <Link
           to='/flood-control-projects/map'
-          className={`px-3 sm:px-4 py-2 border-b-2 ${
+          className={cn(
+            'px-3 sm:px-4 py-2 border-b-2 font-medium flex items-center whitespace-nowrap',
             selectedTab === 'map'
               ? 'border-blue-500'
               : 'text-gray-800 hover:text-blue-600'
-          } font-medium flex items-center whitespace-nowrap`}
+          )}
         >
           <Map className='w-4 h-4 mr-1.5 sm:mr-2' />
           Map


### PR DESCRIPTION
## Summary
Fixes the mobile responsiveness issue in the flood control page where the tab navigation was overflowing on small screens.

## The Root Cause
The tab navigation component had 4 tabs (Visual, Table, Contractors, Map) that would overflow the viewport width on small devices like iPhone SE (320px width), causing horizontal scrolling of the entire page.

## Solution
Made the tab navigation horizontally scrollable on mobile:
- Added `overflow-x-auto` to allow horizontal scrolling of just the tabs
- Used `min-w-max` to prevent tabs from wrapping
- Added `whitespace-nowrap` to keep tab text on single line
- Reduced padding on mobile for better space utilization

## Before
- Tabs would overflow and cause the entire page to scroll horizontally
- Poor user experience on devices < 400px width

## After
- Tabs are horizontally scrollable within their container
- No page-wide horizontal scrolling
- Smooth scrolling experience for tab navigation

## Screenshot
<img width="386" height="680" alt="image" src="https://github.com/user-attachments/assets/b83461f3-5d62-4c12-b997-971c0a9ecb7f" />

## Testing
Test on mobile devices or browser DevTools at:
- 320px width (iPhone SE)
- 375px width (iPhone X/12)
- 390px width (iPhone 14)

Fixes #157

🤖 Generated with [Claude Code](https://claude.ai/code)