### PR TITLE
fix: vacant uppercase

### DIFF
--- a/src/data/directory/constitutional.json
+++ b/src/data/directory/constitutional.json
@@ -1592,7 +1592,7 @@
     "officials": [
       {
         "role": "General Manager",
-        "name": "vacant"
+        "name": "VACANT"
       }
     ],
     "email": "info@ndc.gov.ph"
@@ -2211,7 +2211,7 @@
     "officials": [
       {
         "role": "President",
-        "name": "vacant"
+        "name": "VACANT"
       }
     ],
     "email": "info@doftaxacademy.gov.ph"
@@ -2238,7 +2238,7 @@
     "officials": [
       {
         "role": "Chairperson and President",
-        "name": "vacant"
+        "name": "VACANT"
       }
     ]
   },

--- a/src/data/directory/departments.json
+++ b/src/data/directory/departments.json
@@ -896,7 +896,7 @@
         "email": "asec.rec007@dar.gov.ph"
       },
       {
-        "name": "vacant",
+        "name": "VACANT",
         "role": "Policy, Planning and Research Office",
         "contact": "8426-9288",
         "email": "asec.ppro@dar.gov.ph"
@@ -5328,7 +5328,7 @@
       }
     ],
     "public_assistance_desk": {
-      "director": "vacant",
+      "director": "VACANT",
       "office": "Defense Communications Service",
       "contact": "8982-5611"
     },
@@ -5506,7 +5506,7 @@
         "email": "malig.medmier@dpwh.gov.ph"
       },
       {
-        "name": "vacant",
+        "name": "VACANT",
         "role": "Legal Services",
         "contact": "5304-3232",
         "email": "versoza.mel_john@dpwh.gov.ph"

--- a/src/data/directory/diplomatic.json
+++ b/src/data/directory/diplomatic.json
@@ -147,7 +147,7 @@
       "contact": "8800-9163; 8825-5513 F",
       "email": "efilipinas@cancilliera.gov.co",
       "website": "https://filipinas.embajada.gov.co",
-      "representative": "vacant",
+      "representative": "VACANT",
       "title": null
     },
     {
@@ -288,7 +288,7 @@
       "address": "2209 Paraiso cor. Acacia St., Dasmariñas Village, Makati City",
       "contact": "8843-8880; 8843-3081",
       "email": "manemb@mofa.gov.iq",
-      "representative": "vacant",
+      "representative": "VACANT",
       "title": "Ambassador Extraordinary and Plenipotentiary"
     },
     {
@@ -374,7 +374,7 @@
       "address": "2056 Lumbang cor. Caballero St., Dasmariñas Village, Makati City",
       "contact": "8817-7331 to 32; 8817-7337 F",
       "email": "libya_emb_ph@foreign.gov.ly",
-      "representative": "vacant",
+      "representative": "VACANT",
       "title": "Ambassador Extraordinary and Plenipotentiary"
     },
     {
@@ -460,7 +460,7 @@
       "contact": "8843-9866; 8843-9868",
       "email": "manilanigeria@gmail.com",
       "website": "www.nigeria-manila.org",
-      "representative": "vacant",
+      "representative": "VACANT",
       "title": null
     },
     {
@@ -512,7 +512,7 @@
       "address": "Unit 22-D, Chatham House Condomimium, 116 Valero corner Rufino Streets, Salcedo Village, Makati City",
       "contact": "8551-9094",
       "email": "palestinemanila@gmail.com",
-      "representative": "vacant",
+      "representative": "VACANT",
       "title": null
     },
     {
@@ -532,7 +532,7 @@
       "address": "3/F Corinthian Plaza Bldg., Paseo de Roxas cor. Gamboa St., Legaspi Village, Makati City",
       "contact": "8811-3465; 8811-3466; 8811-3468 F",
       "email": "kundumnl@pngembmnl.com.ph",
-      "representative": "vacant",
+      "representative": "VACANT",
       "title": null
     },
     {
@@ -651,7 +651,7 @@
       "contact": "8811-7900; 8811-7940 F",
       "email": "ambassaden.manila@gov.se",
       "website": "www.swedenabroad.com/Manila",
-      "representative": "vacant",
+      "representative": "VACANT",
       "title": "Charge d'Affaires"
     },
     {

--- a/src/data/directory/legislative.json
+++ b/src/data/directory/legislative.json
@@ -357,7 +357,7 @@
       },
       {
         "role": "Director General",
-        "name": "vacant",
+        "name": "VACANT",
         "office": "Senate Economic Planning Office",
         "contact": "loc. 4176; 8552-6823"
       }
@@ -2662,7 +2662,7 @@
       },
       {
         "role": "Deputy Secretary General",
-        "name": "vacant",
+        "name": "VACANT",
         "office": "Engineering and Physical Facilities Department",
         "contact": "loc. 7456, 7458; 8931-6611; 8931-5860 F",
         "email": "engr.dept@house.gov.ph"


### PR DESCRIPTION
This PR updates all instances of "vacant" to "VACANT" across relevant data files for consistency.

Examples:

- Ethics and Privileges: VACANT
- Director General: VACANT

_See attached screenshots for before/after comparison._

<img width="476" height="137" alt="image" src="https://github.com/user-attachments/assets/114db319-e60c-4b25-a330-ffa0a1a01184" />
<img width="474" height="84" alt="image" src="https://github.com/user-attachments/assets/c72ce5be-b583-4732-a549-df215b97fde1" />

