### PR TITLE
fix: make Ticker items responsive on mobile

### DIFF
--- a/src/components/ui/Ticker.tsx
+++ b/src/components/ui/Ticker.tsx
@@ -178,9 +178,9 @@ const Ticker: React.FC = () => {
               weatherData.slice(0, 4).map(data => (
                 <div
                   key={data.location}
-                  className='flex items-center space-x-2 uppercase'
+                  className='flex flex-col items-center justify-center uppercase space-x-0 sm:flex-row sm:space-x-2'
                 >
-                  <span className='text-xs font-medium text-accent-100'>
+                  <span className='text-[11px] sm:text-xs font-medium text-accent-100'>
                     {data.location}
                   </span>
                   <span className='text-xs text-white'>


### PR DESCRIPTION
- Minor UI adjustments for Ticker elements to make it responsive in mobile

From: 
<img width="467" height="338" alt="image" src="https://github.com/user-attachments/assets/c54f0f94-68ba-4a14-8e06-88f8622dc115" />

To:
<img width="469" height="336" alt="image" src="https://github.com/user-attachments/assets/4f6bc643-accf-428f-89b0-e12638b0798e" />
