### PR TITLE
fix: make local government units responsive

### DIFF
--- a/src/pages/government/local/index.tsx
+++ b/src/pages/government/local/index.tsx
@@ -62,8 +62,8 @@ export default function LocalGovernmentIndex() {
   return (
     <>
       <SEO {...seoData} />
-      <div className='space-y-6'>
-        <div className='flex flex-col md:flex-row md:items-center md:justify-between gap-4'>
+      <div className='@container space-y-6'>
+        <div className='flex flex-col @lg:flex-row @lg:items-center @lg:justify-between gap-4'>
           <div>
             <h1 className='text-3xl font-bold text-gray-900 mb-2'>
               Local Government Units
@@ -75,7 +75,7 @@ export default function LocalGovernmentIndex() {
             </p>
           </div>
 
-          <div className='relative w-full md:w-64'>
+          <div className='relative w-full lg:w-64'>
             <Search className='absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400' />
             <input
               type='search'
@@ -98,7 +98,7 @@ export default function LocalGovernmentIndex() {
             <p className='text-gray-800'>Try adjusting your search term.</p>
           </div>
         ) : (
-          <CardGrid columns={3} breakpoint='lg' gap='md'>
+          <CardGrid columns={1} className='@lg:grid-cols-2 @3xl:grid-cols-3'>
             {filteredRegions.map(region => (
               <Link
                 key={region.slug}


### PR DESCRIPTION
Responsiveness will be based on the container instead of the page

## Before
<img width="1021" height="851" alt="image" src="https://github.com/user-attachments/assets/8ac45f55-9d12-41d8-bd45-1517ddd063d9" />

## After
<img width="1002" height="750" alt="image" src="https://github.com/user-attachments/assets/c1d82c9e-7b81-41ab-bbd2-558cec520bb7" />


