### PR TITLE
fix: display real weather data instead of hardcoded values

### DIFF
--- a/src/lib/weather.ts
+++ b/src/lib/weather.ts
@@ -48,9 +48,7 @@ export const fetchWeatherData = async (): Promise<WeatherData[]> => {
       humidity: data[key].main.humidity,
       windSpeed: data[key].wind.speed,
       pressure: data[key].main.pressure,
-      visibility: data[key].visibility
-        ? Math.round(data[key].visibility / 1000)
-        : undefined, // Convert meters to kilometers
+      visibility: Math.round(data[key].visibility / 1000), // Convert meters to kilometers
     })
   );
 

--- a/src/lib/weather.ts
+++ b/src/lib/weather.ts
@@ -45,6 +45,12 @@ export const fetchWeatherData = async (): Promise<WeatherData[]> => {
       temperature: Math.round(data[key].main.temp), // Round temperature to nearest integer
       condition: data[key].weather[0].description,
       icon: mapWeatherIconToLucide(data[key].weather[0].icon),
+      humidity: data[key].main.humidity,
+      windSpeed: data[key].wind.speed,
+      pressure: data[key].main.pressure,
+      visibility: data[key].visibility
+        ? Math.round(data[key].visibility / 1000)
+        : undefined, // Convert meters to kilometers
     })
   );
 

--- a/src/pages/data/weather.tsx
+++ b/src/pages/data/weather.tsx
@@ -149,33 +149,25 @@ const WeatherPage: React.FC = () => {
                     <div className='bg-white/20 backdrop-blur-sm rounded-lg p-4'>
                       <div className='text-black/80 mb-1'>Humidity</div>
                       <div className='text-xl font-semibold'>
-                        {selectedCityData.humidity !== undefined
-                          ? `${selectedCityData.humidity}%`
-                          : 'N/A'}
+                        {selectedCityData.humidity}%
                       </div>
                     </div>
                     <div className='bg-white/20 backdrop-blur-sm rounded-lg p-4'>
                       <div className='text-black/80 mb-1'>Wind</div>
                       <div className='text-xl font-semibold'>
-                        {selectedCityData.windSpeed !== undefined
-                          ? `${Math.round(selectedCityData.windSpeed * 3.6)} km/h`
-                          : 'N/A'}
+                        {Math.round(selectedCityData.windSpeed * 3.6)} km/h
                       </div>
                     </div>
                     <div className='bg-white/20 backdrop-blur-sm rounded-lg p-4'>
                       <div className='text-black/80 mb-1'>Pressure</div>
                       <div className='text-xl font-semibold'>
-                        {selectedCityData.pressure !== undefined
-                          ? `${selectedCityData.pressure} hPa`
-                          : 'N/A'}
+                        {selectedCityData.pressure} hPa
                       </div>
                     </div>
                     <div className='bg-white/20 backdrop-blur-sm rounded-lg p-4'>
                       <div className='text-black/80 mb-1'>Visibility</div>
                       <div className='text-xl font-semibold'>
-                        {selectedCityData.visibility !== undefined
-                          ? `${selectedCityData.visibility} km`
-                          : 'N/A'}
+                        {selectedCityData.visibility} km
                       </div>
                     </div>
                   </div>

--- a/src/pages/data/weather.tsx
+++ b/src/pages/data/weather.tsx
@@ -148,19 +148,35 @@ const WeatherPage: React.FC = () => {
                   <div className='grid grid-cols-2 md:grid-cols-4 gap-4 text-center'>
                     <div className='bg-white/20 backdrop-blur-sm rounded-lg p-4'>
                       <div className='text-black/80 mb-1'>Humidity</div>
-                      <div className='text-xl font-semibold'>65%</div>
+                      <div className='text-xl font-semibold'>
+                        {selectedCityData.humidity !== undefined
+                          ? `${selectedCityData.humidity}%`
+                          : 'N/A'}
+                      </div>
                     </div>
                     <div className='bg-white/20 backdrop-blur-sm rounded-lg p-4'>
                       <div className='text-black/80 mb-1'>Wind</div>
-                      <div className='text-xl font-semibold'>12 km/h</div>
+                      <div className='text-xl font-semibold'>
+                        {selectedCityData.windSpeed !== undefined
+                          ? `${Math.round(selectedCityData.windSpeed * 3.6)} km/h`
+                          : 'N/A'}
+                      </div>
                     </div>
                     <div className='bg-white/20 backdrop-blur-sm rounded-lg p-4'>
                       <div className='text-black/80 mb-1'>Pressure</div>
-                      <div className='text-xl font-semibold'>1013 hPa</div>
+                      <div className='text-xl font-semibold'>
+                        {selectedCityData.pressure !== undefined
+                          ? `${selectedCityData.pressure} hPa`
+                          : 'N/A'}
+                      </div>
                     </div>
                     <div className='bg-white/20 backdrop-blur-sm rounded-lg p-4'>
                       <div className='text-black/80 mb-1'>Visibility</div>
-                      <div className='text-xl font-semibold'>10 km</div>
+                      <div className='text-xl font-semibold'>
+                        {selectedCityData.visibility !== undefined
+                          ? `${selectedCityData.visibility} km`
+                          : 'N/A'}
+                      </div>
                     </div>
                   </div>
                 </div>

--- a/src/pages/government/legislative/components/LegislativeSidebar.tsx
+++ b/src/pages/government/legislative/components/LegislativeSidebar.tsx
@@ -23,7 +23,9 @@ export default function LegislativeSidebar() {
               <Link
                 to='/government/legislative/senate-of-the-philippines-20th-congress'
                 className={`flex items-center px-3 py-2 text-sm rounded-md transition-colors ${
-                  isActive('/government/legislative/senate-of-the-philippines-20th-congress')
+                  isActive(
+                    '/government/legislative/senate-of-the-philippines-20th-congress'
+                  )
                     ? 'bg-primary-50 text-primary-700 font-medium'
                     : 'text-gray-700 hover:bg-gray-50'
                 }`}
@@ -58,7 +60,9 @@ export default function LegislativeSidebar() {
               <Link
                 to='/government/legislative/house-of-representatives-20th-congress'
                 className={`flex items-center px-3 py-2 text-sm rounded-md transition-colors ${
-                  isActive('/government/legislative/house-of-representatives-20th-congress')
+                  isActive(
+                    '/government/legislative/house-of-representatives-20th-congress'
+                  )
                     ? 'bg-primary-50 text-primary-700 font-medium'
                     : 'text-gray-700 hover:bg-gray-50'
                 }`}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -46,10 +46,10 @@ export interface WeatherData {
   temperature: number;
   condition: string;
   icon: string;
-  humidity?: number;
-  windSpeed?: number;
-  pressure?: number;
-  visibility?: number;
+  humidity: number;
+  windSpeed: number;
+  pressure: number;
+  visibility: number;
 }
 
 export interface ForexRate {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -46,6 +46,10 @@ export interface WeatherData {
   temperature: number;
   condition: string;
   icon: string;
+  humidity?: number;
+  windSpeed?: number;
+  pressure?: number;
+  visibility?: number;
 }
 
 export interface ForexRate {


### PR DESCRIPTION
## Summary
Fixes the hardcoded weather data issue in the weather page by displaying actual data from the OpenWeatherMap API.

## Changes
- Added `humidity`, `windSpeed`, `pressure`, and `visibility` fields to the `WeatherData` type
- Updated `fetchWeatherData` function to retrieve and return these additional fields from the API
- Modified the weather page component to display actual data instead of hardcoded values
- Wind speed is converted from m/s to km/h for better readability
- Visibility is converted from meters to kilometers

## Before
Weather details (humidity, wind, pressure, visibility) were showing static hardcoded values:
- Humidity: Always 65%
- Wind: Always 12 km/h
- Pressure: Always 1013 hPa
- Visibility: Always 10 km

## After
Weather details now display real-time data from the OpenWeatherMap API for each city.

Fixes #195