### PR TITLE
fix: correct Leaflet marker icon file extension

### DIFF
--- a/src/pages/flood-control-projects/contractors/[contractor-name].tsx
+++ b/src/pages/flood-control-projects/contractors/[contractor-name].tsx
@@ -908,7 +908,7 @@ const ContractorDetail: React.FC = () => {
                         key={project.GlobalID || project.objectID}
                         position={[lat, lng]}
                         icon={L.icon({
-                          iconUrl: '/marker-icon-2x.png',
+                          iconUrl: '/marker-icon-2x.webp',
                           iconSize: [16, 24],
                           iconAnchor: [8, 8],
                           popupAnchor: [0, -25],

--- a/src/pages/flood-control-projects/map.tsx
+++ b/src/pages/flood-control-projects/map.tsx
@@ -431,7 +431,7 @@ const FloodControlProjectsMap: React.FC = () => {
                         key={project.GlobalID || project.objectID}
                         position={[lat, lng]}
                         icon={L.icon({
-                          iconUrl: '/marker-icon-2x.png',
+                          iconUrl: '/marker-icon-2x.webp',
                           iconSize: [16, 24],
                           iconAnchor: [8, 8],
                           popupAnchor: [0, -25],


### PR DESCRIPTION
- Change marker-icon-2x.png to marker-icon-2x.webp
- Fixes Issue #176: Leaflet markers appear as broken icons
- Uses existing WebP marker file instead of missing PNG file

Resolves: #176