### PR TITLE
build: do not exclude `lucide-react` from pre-bundling

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,4 @@ import react from '@vitejs/plugin-react';
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-  optimizeDeps: {
-    exclude: ['lucide-react'],
-  },
 });


### PR DESCRIPTION
Excluding the `lucide-react` package from being pre-bundled was causing issues in some development environments, only showing a white screen. This makes `lucide-react` able to be pre-bundled again, solving the white screen issue. 