### PR TITLE
fix(search): prevent icon/input overlap 

### DIFF
--- a/src/components/search/MeilisearchInstantSearch.css
+++ b/src/components/search/MeilisearchInstantSearch.css
@@ -33,7 +33,8 @@
 /* Ensure SearchBox input has good contrast and size */
 .ais-SearchBox-input {
   font-size: 1rem;
-  padding: 0.75rem 1rem;
+  /* Ensure space for right action buttons; left aligns like normal when typing */
+  padding: 0.75rem 5rem 0.75rem 1rem;
 }
 
 /* Style for refinement list */
@@ -98,8 +99,10 @@
   color: #4b5563; /* text-gray-800 */
 }
 
-input.ais-SearchBox-input:placeholder-shown:not(:focus) {
-  padding-left: 40px; /* Firefox-safe way to 'move' placeholder */
+/* Remove placeholder-specific padding; maintain consistent padding at all times */
+/* When not focused (icon visible via form::before), add left padding to clear icon */
+form.ais-SearchBox-form:not(:focus-within) .ais-SearchBox-input {
+  padding-left: 2.5rem;
 }
 
 input.ais-SearchBox-input::placeholder {


### PR DESCRIPTION
## fix(search): prevent icon/input overlap

### Summary
- Adjust `.ais-SearchBox-input` padding so text no longer overlaps the left search icon or the right-side reset/submit buttons.
- Behavior now matches the intended UX:
  - Not focused: input adds extra left padding to clear the icon.
  - Focused/typing: input uses normal left padding (no extra gap while typing).

### Before
<img width="1132" height="66" alt="image" src="https://github.com/user-attachments/assets/54e7f952-7863-4fe0-b21a-f4c99314e39e" />


### After
<img width="1141" height="66" alt="image" src="https://github.com/user-attachments/assets/8fadae64-bdda-4745-857a-23d51502c05a" />

### Changes
- CSS: `src/components/search/MeilisearchInstantSearch.css`
  - Base: `padding: 0.75rem 5rem 0.75rem 1rem;`
  - When not focused: `form.ais-SearchBox-form:not(:focus-within) .ais-SearchBox-input { padding-left: 2.5rem; }`
  - Keeps right padding to clear reset/submit buttons.

### Rationale
- Prevent input text from overlapping the search icon.
- Avoid a permanent left gap while typing, maintaining a natural caret position.

### Testing
- Manual visual verification across focus/blur states.
- Confirmed no linter issues.

### Risks / Rollback
- Low: Limited to search input styles. Rollback by reverting the CSS edits in the file above.

### Checklist
- [x] Conventional commit message
- [x] Branch rebased on latest `main`
- [x] Screenshots added (before/after)
- [x] Accessibility: focus styles unaffected


