### PR TITLE
docs: add contributing section in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,13 @@ test('user can search for services', async ({ page }) => {
 });
 ```
 
+## Contributing
+Thanks to all the people who already contributed!
+
+<a href="https://github.com/bettergovph/bettergov/graphs/contributors">
+    <img src="https://contributors-img.web.app/image?repo=bettergovph/bettergov&max=750&columns=20" />
+</a>
+
 ## License
 
 This project is released under the [Creative Commons CC0](https://creativecommons.org/publicdomain/zero/1.0/) dedication. This means the work is dedicated to the public domain and can be freely used by anyone for any purpose without restriction under copyright law.


### PR DESCRIPTION
This adds all of the contributors (rank by contributions) to README so atleast contributors feel awarded.
Contributions made by AI and co-authors of commits are excluded. This is similar to the README contributions section from [nushell](https://github.com/nushell/nushell/tree/main?tab=readme-ov-file#contributing).

<img width="863" height="242" alt="image" src="https://github.com/user-attachments/assets/b2546e62-7302-4bec-9185-035250554025" />
