### PR TITLE
fix: update favicon for better visibility in dark mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <link
       rel="icon"
       type="image/svg+xml"
-      href="/logos/svg/BetterGov_Icon-Primary.svg"
+      href="/logos/svg/BetterGov_Emblem-Outline-Inversed.svg"
     />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>


### PR DESCRIPTION
This PR updates the favicon to improve visibility in both dark mode and light mode.

- Replaced BetterGov_Icon-Primary.svg with BetterGov_Emblem-Outline-Inversed.svg
- Ensures favicon looks consistent across different themes and browser tabs

**Before:**

Light Mode:
<img width="319" height="107" alt="image" src="https://github.com/user-attachments/assets/4b13e5d4-6dfa-4c5a-a860-33440f17e70e" />

 _Honestly, it looks fine in light mode._

Dark Mode:
<img width="319" height="107" alt="image" src="https://github.com/user-attachments/assets/bccd714f-67a5-45c2-a661-f3f5a2fc2e91" />

_Here we can see, it looks so off. I guess the contrast is not there to visualize the logo._

**After:**

Light Mode:
<img width="319" height="107" alt="image" src="https://github.com/user-attachments/assets/e1867b30-0b57-4ef6-b78a-eb7164c07ac0" />

Dark Mode:
<img width="319" height="107" alt="image" src="https://github.com/user-attachments/assets/d665d2e3-f7c7-4365-84a7-266d07605056" />
