### PR TITLE
FIx: Remove Mayor and Vice Mayor redundant label

### DIFF
--- a/src/pages/government/local/[region].tsx
+++ b/src/pages/government/local/[region].tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo } from 'react';
 import { useParams } from 'react-router-dom';
-import { Search, MapPin, User, Crown } from 'lucide-react';
+import { Search, MapPin } from 'lucide-react';
 import lguData from '../../../data/directory/lgu.json';
 import {
   CardGrid,
@@ -203,13 +203,6 @@ export default function RegionalLGUPage() {
 
                   {/* Mayor Section */}
                   <div className='mb-6'>
-                    <div className='flex items-center mb-3'>
-                      <Crown className='h-4 w-4 text-yellow-600 mr-2' />
-                      <span className='text-sm font-medium text-gray-700'>
-                        Mayor
-                      </span>
-                    </div>
-
                     <div className='flex items-start space-x-3'>
                       <CardAvatar name={unit.mayor?.name || ''} size='sm' />
                       <div className='flex-1 min-w-0'>
@@ -232,13 +225,6 @@ export default function RegionalLGUPage() {
                   {/* Vice Mayor Section */}
                   {unit.vice_mayor && (
                     <div>
-                      <div className='flex items-center mb-3'>
-                        <User className='h-4 w-4 text-blue-600 mr-2' />
-                        <span className='text-sm font-medium text-gray-700'>
-                          Vice Mayor
-                        </span>
-                      </div>
-
                       <div className='flex items-start space-x-3'>
                         <CardAvatar name={unit.vice_mayor.name} size='sm' />
                         <div className='flex-1 min-w-0'>


### PR DESCRIPTION
## Changes
- remove mayor and vice mayor additional label

## Before
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/d2aae9c3-70e8-4ec4-9e8c-e3bc676922f9" />


## After
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/a3ff4dd8-e868-4554-abea-13b50db57fc8" />
