### PR TITLE
feat(services): make Categories sidebar sticky to improve UX

### DIFF
--- a/src/pages/services/index.tsx
+++ b/src/pages/services/index.tsx
@@ -314,11 +314,11 @@ export default function ServicesPage() {
             role='navigation'
             aria-label='Service categories'
           >
-            <div className='bg-white rounded-lg shadow-xs p-4'>
+            <div className='bg-white rounded-lg shadow-xs p-4 sticky top-[8.25rem]'>
               <h2 className='font-semibold text-gray-900 mb-4 text-lg'>
                 Categories
               </h2>
-              <ScrollArea.Root className='h-[calc(60vh)] md:h-[calc(100vh-400px)]'>
+              <ScrollArea.Root className='h-[calc(60vh)] md:max-h-[calc(100vh-200px)]'>
                 <ScrollArea.Viewport className='h-full w-full'>
                   <div className='space-y-1 pr-4' role='list'>
                     <div role='listitem'>


### PR DESCRIPTION
## feat(services): sticky Categories sidebar
- Ensures the inner list scrolls without overflowing while the card stays pinned.


https://github.com/user-attachments/assets/dd91aab9-52a9-4392-bf11-a9a260ce5668



### Changes
- **File: `src/pages/services/index.tsx`**
  - Added sticky positioning with top offset to the Categories card container.
  - Set a `max-height` on the scroll area to avoid overflow.

### Rationale
- **Usability**: Persistent access to categories during browsing.

### Testing
- Verified on Chrome/Firefox/Safari at common viewport widths (tablet, and desktop).
- Confirmed sticky offset leaves room for the site header.
- Ensured keyboard navigation and focus states remain intact.

### Risks / Rollback
- **Low**: Purely presentational change within a single page.
- **Rollback**: Revert `src/pages/services/index.tsx`.

### Checklist
- [x] Branch from latest `main`
- [x] Sticky does not overlap header
- [x] Scroll area constrained and accessible
- [x] No functional regressions

