### PR TITLE
fix(legislative): render Secretariat email links and prevent overflow

### DIFF
--- a/src/pages/government/legislative/[chamber].tsx
+++ b/src/pages/government/legislative/[chamber].tsx
@@ -70,7 +70,7 @@ function LegislativeDetailSection({
                   <a
                     href={`mailto:${value}`}
                     className='text-primary-600 hover:underline leading-relaxed break-all'
-                    style={{ wordBreak: 'break-all' }}
+                   
                   >
                     <span className='sr-only'>Email</span>
                     {String(value)}

--- a/src/pages/government/legislative/[chamber].tsx
+++ b/src/pages/government/legislative/[chamber].tsx
@@ -1,5 +1,5 @@
 import { useParams } from 'react-router-dom';
-import { ExternalLink, MapPin, Phone, Globe } from 'lucide-react';
+import { ExternalLink, MapPin, Phone, Globe, Mail } from 'lucide-react';
 import legislativeData from '../../../data/directory/legislative.json';
 import { cn } from '../../../lib/utils';
 
@@ -45,7 +45,6 @@ function LegislativeDetailSection({
     'address',
     'trunkline',
     'website',
-    'email',
   ];
 
   if (isSimpleObject) {
@@ -58,6 +57,28 @@ function LegislativeDetailSection({
       >
         {Object.entries(data).map(([key, value]) => {
           if (skipKeys.includes(key) || value === undefined) return null;
+
+          // Special rendering for email so it's visible and wraps cleanly
+          if (key === 'email' && value) {
+            return (
+              <div key={key} className='text-sm'>
+                <div className='flex items-start'>
+                  <Mail
+                    className='h-4 w-4 text-gray-400 mr-2 mt-0.5 flex-shrink-0'
+                    aria-hidden='true'
+                  />
+                  <a
+                    href={`mailto:${value}`}
+                    className='text-primary-600 hover:underline leading-relaxed break-all'
+                    style={{ wordBreak: 'break-all' }}
+                  >
+                    <span className='sr-only'>Email</span>
+                    {String(value)}
+                  </a>
+                </div>
+              </div>
+            );
+          }
 
           return (
             <div key={key} className='text-sm'>


### PR DESCRIPTION
This renders email addresses for Secretariat Officials on legislative chamber pages as mailto: links, adds a decorative Mail icon (aria-hidden), and prevents layout overflow for long email strings with break-all styling and wordBreak. This is a UI-only fix; no data changes are included in this PR.

<img width="7680" height="4320" alt="localhost_5173_government_legislative_senate-of-the-philippines-20th-congress(HD)" src="https://github.com/user-attachments/assets/e12bde09-b185-4d9a-b13c-4426d2fcdaca" />
<img width="1290" height="2795" alt="localhost_5173_government_legislative_senate-of-the-philippines-20th-congress(iPhone 14 Pro Max)" src="https://github.com/user-attachments/assets/23db7b41-5cec-4408-b553-140a53993bad" />
