### PR TITLE
docs: Update Share ideas in Discussions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,8 @@ Refer to the following channels to connect with fellow contributors or to stay u
 To share your new ideas for the project, perform the following actions:
 
 1. Reach out via email [volunteers@bettergov.ph](mailto:volunteers@bettergov.ph)
-2. Submit ideas in [Discussions][discussions]
+2. Discord Ideas Forum: ⁠[ideas](https://discord.com/channels/1415670958710325270/1418544879717318826)
+3. Submit ideas in [Github Discussions][discussions]
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,7 @@ Refer to the following channels to connect with fellow contributors or to stay u
 To share your new ideas for the project, perform the following actions:
 
 1. Reach out via email [volunteers@bettergov.ph](mailto:volunteers@bettergov.ph)
-2. Open an issue in this [repository][issues]
+2. Submit ideas in [Discussions][discussions]
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
@@ -333,3 +333,4 @@ git push
 [issues]: https://github.com/bettergovph/bettergov/issues/new
 [forking]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo
 [discord]: https://discord.gg/mHtThpN8bT
+[discussions]: https://github.com/orgs/bettergovph/discussions


### PR DESCRIPTION
# Changes
- Updated CONTRIBUTING.md to share ideas in Discord forum and Github Discussions page
 
# Reason

We've moved all idea-related GitHub issues to the Discussions tab under the "Ideas" category. From now on, we would like to ask everyone who wants to share any new ideas to do so in one of these places:

Discord Ideas Forum: ⁠ideas
[GitHub Discussions](https://github.com/bettergovph/bettergov/discussions/categories/ideas)



See https://discord.com/channels/1415670958710325270/1418546658706329631/1421329022805348382