### PR TITLE
fix(flag): prevent image from being draggable

### DIFF
--- a/src/pages/travel/visa/index.tsx
+++ b/src/pages/travel/visa/index.tsx
@@ -556,6 +556,7 @@ const VisaPage: React.FC = () => {
                             title={country}
                             alt={country}
                             loading='lazy'
+                            draggable={false}
                             className='block w-full h-full object-cover transform -translate-x-6 opacity-100 transition-all duration-700 ease-[cubic-bezier(.22,.61,.36,1)] delay-75 group-hover:translate-x-0 group-hover:opacity-100 group-hover:scale-[1.02] will-change-transform motion-reduce:transition-none motion-reduce:transform-none'
                           />
                         )}


### PR DESCRIPTION
### Description

This PR updates the Visa Information page under the Travel section to make the flag image non-draggable. This prevents accidental dragging, improving the overall user experience, especially on desktop devices.

### Changes Made

- Added `draggable={false}` to the flag image element.

### Issue
<img width="493" height="290" alt="image" src="https://github.com/user-attachments/assets/9d03eb98-4cf8-43d5-8383-4e8a50d8cf95" />
