### PR TITLE
fix(services): update PSRTI training title and enrollment link

### DIFF
--- a/src/data/services/education.json
+++ b/src/data/services/education.json
@@ -108,8 +108,8 @@
     "updatedAt": "2025-06-06T11:30:06.319Z"
   },
   {
-    "service": "Register Online for 2019 PSRTI Regular Training Courses",
-    "url": "https://docs.google.com/forms/d/e/1FAIpQLSd8CDP2gbHIDFyD4Jxp79PL7EaTdwILuReytxiR-s7SCa1Byg/viewform",
+    "service": "Register Online for PSRTI Regular Training Courses",
+    "url": "https://psrti.gov.ph/training/enrollment/",
     "id": "f127deec-ea3e-4a3a-b9bc-8c202f379bb2",
     "slug": "register-online-for-2019-psrti-regular-training-courses",
     "published": true,


### PR DESCRIPTION
### Description
This PR updates the PSRTI Training Courses service section to remove outdated information and ensure users are directed to the correct enrollment page. The previous title referenced "2019" and linked to a Google Form that is no longer accepting responses.

### Changes Made
- Updated the title from "Register Online for 2019 PSRTI Regular Training Courses" to a more relevant version without a year reference.
- Replaced the outdated Google Form link with the official PSRTI website enrollment page.

### Before
<img width="768" height="317" alt="image" src="https://github.com/user-attachments/assets/0186ff63-3d31-4712-9469-0bb5f35d9efa" />

### After
<img width="768" height="317" alt="image" src="https://github.com/user-attachments/assets/34f40b48-14ba-433c-942f-d4c36b0d58ef" />