### PR TITLE
fix(footer): update Discord link

### DIFF
--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -114,7 +114,7 @@ export const footerNavigation = {
   ],
   socialLinks: [
     { label: 'Facebook', href: 'https://facebook.com/bettergovph' },
-    { label: 'Discord', href: 'https://discord.gg/bettergovph' },
+    { label: 'Discord', href: '/discord' },
     // { label: 'Instagram', href: 'https://instagram.com/govph' },
     // { label: 'YouTube', href: 'https://youtube.com/govph' },
   ],

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -114,7 +114,7 @@ export const footerNavigation = {
   ],
   socialLinks: [
     { label: 'Facebook', href: 'https://facebook.com/bettergovph' },
-    { label: 'Discord', href: '/discord' },
+    { label: 'Discord', href: 'https://discord.gg/bettergovph' },
     // { label: 'Instagram', href: 'https://instagram.com/govph' },
     // { label: 'YouTube', href: 'https://youtube.com/govph' },
   ],

--- a/src/pages/Discord.tsx
+++ b/src/pages/Discord.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 
 export default function Discord() {
   useEffect(function () {
-    window.location.assign('https://discord.gg/5xBQmjWm');
+    window.location.assign('https://discord.gg/bettergovph');
   }, []);
   return <h1>Redirecting to BetterGov.ph Discord Invite Link...</h1>;
 }


### PR DESCRIPTION
### Description
This PR updates the Discord link in the website footer. The previous link was outdated, preventing users from joining the community directly. This update ensures visitors are redirected to the correct and active Discord invite.

Fixes #356

### Changes Made
- Updated the footer’s Discord link to the official and active invite URL.