### PR TITLE
fix(services): remove outdated SBWS application link

### DIFF
--- a/src/data/services/social-services.json
+++ b/src/data/services/social-services.json
@@ -178,23 +178,5 @@
     },
     "createdAt": "2025-06-06T11:30:06.320Z",
     "updatedAt": "2025-06-06T11:30:06.320Z"
-  },
-  {
-    "service": "Apply for Small Business Wage Subsidy (SBWS) Online",
-    "url": "https://www.sss.gov.ph/",
-    "id": "c9d5d924-121d-484c-844e-d83b792744f0",
-    "slug": "apply-for-small-business-wage-subsidy-sbws-online",
-    "published": true,
-    "featured": false,
-    "category": {
-      "name": "Social Services",
-      "slug": "social-services"
-    },
-    "subcategory": {
-      "name": "Financial Assistance",
-      "slug": "financial-assistance"
-    },
-    "createdAt": "2025-06-06T11:30:06.320Z",
-    "updatedAt": "2025-06-06T11:30:06.320Z"
   }
 ]


### PR DESCRIPTION
### Description

This PR removes the outdated Small Business Wage Subsidy (SBWS) Online application link from the Services section.

The Small Business Wage Subsidy (SBWS) program was a temporary COVID-19 relief measure under the Bayanihan to Heal as One Act (RA 11469). It ended in 2020 and was not extended or reopened. Users are advised to check the BIR, SSS, DOF, or DTI for current support programs.

### Changes Made
- Removed the Apply for Small Business Wage Subsidy (SBWS) Online option from the Services section.

<img width="804" height="325" alt="image" src="https://github.com/user-attachments/assets/a9dfd242-cc16-4d54-93b6-af1faa579bb5" />
