### PR TITLE
Legislative Chamber + Senate Commitees Page enhancement

### DIFF
--- a/src/pages/government/legislative/[chamber].tsx
+++ b/src/pages/government/legislative/[chamber].tsx
@@ -5,21 +5,150 @@ import {
   PhoneIcon,
   GlobeIcon,
   Mail,
+  UserIcon,
+  UsersIcon,
 } from 'lucide-react';
 
 import legislativeData from '../../../data/directory/legislative.json';
 import { cn } from '../../../lib/utils';
+import { Card, CardHeader, CardContent } from '../../../components/ui/CardList';
+
+// Component to render officials in a card grid
+function OfficialsGrid({
+  officials,
+}: {
+  officials: Array<{
+    role: string;
+    name: string;
+    contact?: string;
+    office?: string;
+  }>;
+}) {
+  return (
+    <div className='grid grid-cols-1 @lg:grid-cols-2 @2xl:grid-cols-3 gap-6'>
+      {officials.map((official, index) => (
+        <Card key={index} hover={false} className='h-full flex flex-col'>
+          <CardHeader className='flex-none'>
+            <div className='flex items-start justify-between gap-3'>
+              <div className='flex-1'>
+                <h3 className='font-semibold text-base text-gray-900 leading-tight'>
+                  {official.name}
+                </h3>
+                <p className='text-sm text-primary-600 font-medium mt-1'>
+                  {official.role}
+                </p>
+                {official.office && (
+                  <p className='text-xs text-gray-600 mt-1 line-clamp-2'>
+                    {official.office}
+                  </p>
+                )}
+              </div>
+              <div className='rounded-full bg-gray-100 p-2 shrink-0'>
+                <UserIcon className='h-5 w-5 text-gray-600' />
+              </div>
+            </div>
+          </CardHeader>
+          {official.contact && official.contact !== '__' && (
+            <CardContent className='flex-1'>
+              <div className='flex items-start gap-2 text-sm'>
+                <PhoneIcon className='h-4 w-4 text-gray-400 flex-shrink-0 mt-0.5' />
+                <span className='text-gray-700'>{official.contact}</span>
+              </div>
+            </CardContent>
+          )}
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+// Component to render committees in a card grid
+function CommitteesGrid({
+  committees,
+}: {
+  committees: Array<{ committee: string; chairperson: string }>;
+}) {
+  return (
+    <div className='grid grid-cols-1 @lg:grid-cols-2 @3xl:grid-cols-3 gap-6'>
+      {committees.map((committee, index) => (
+        <Card key={index} hover={false} className='h-full flex flex-col'>
+          <CardHeader className='flex-none'>
+            <h3 className='font-semibold text-base text-gray-900 leading-snug line-clamp-2 min-h-[2.5rem]'>
+              {committee.committee}
+            </h3>
+          </CardHeader>
+          <CardContent className='flex-1 flex flex-col justify-between'>
+            <div className='flex items-center gap-2 text-sm'>
+              <UsersIcon className='h-4 w-4 text-gray-400 flex-shrink-0' />
+              <div className='flex flex-col'>
+                <span className='text-xs font-medium text-gray-500 uppercase tracking-wide'>
+                  Chairperson
+                </span>
+                <span className='font-medium text-gray-900 mt-0.5'>
+                  {committee.chairperson}
+                </span>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}
 
 // Recursive component to render legislative details
 function LegislativeDetailSection({
   data,
   level = 0,
+  sectionKey = '',
 }: {
   data: unknown;
   level?: number;
+  sectionKey?: string;
 }) {
   if (data === null || typeof data !== 'object') {
     return <span className='text-gray-700'>{String(data)}</span>;
+  }
+
+  // Special handling for officials array
+  if (Array.isArray(data) && sectionKey === 'officials') {
+    return (
+      <OfficialsGrid
+        officials={
+          data as Array<{
+            role: string;
+            name: string;
+            contact?: string;
+            office?: string;
+          }>
+        }
+      />
+    );
+  }
+
+  // Special handling for secretariat officials
+  if (Array.isArray(data) && sectionKey === 'secretariat_officials') {
+    return (
+      <OfficialsGrid
+        officials={
+          data as Array<{
+            role: string;
+            name: string;
+            contact?: string;
+            office?: string;
+          }>
+        }
+      />
+    );
+  }
+
+  // Special handling for permanent committees
+  if (Array.isArray(data) && sectionKey === 'permanent_committees') {
+    return (
+      <CommitteesGrid
+        committees={data as Array<{ committee: string; chairperson: string }>}
+      />
+    );
   }
 
   if (Array.isArray(data)) {
@@ -32,7 +161,11 @@ function LegislativeDetailSection({
               level > 0 ? 'ml-4 border-l border-b border-neutral-100 pl-3' : ''
             }`}
           >
-            <LegislativeDetailSection data={item} level={level + 1} />
+            <LegislativeDetailSection
+              data={item}
+              level={level + 1}
+              sectionKey={sectionKey}
+            />
           </div>
         ))}
       </div>
@@ -105,7 +238,7 @@ function LegislativeDetailSection({
   if (entries.length === 0) return null;
 
   return (
-    <div className='@container space-y-4'>
+    <div className='@container space-y-6'>
       {entries.map(([key, value]) => {
         if (value === undefined || value === null) return null;
 
@@ -118,22 +251,20 @@ function LegislativeDetailSection({
 
         return (
           <div key={key} className='pb-4'>
-            <div className='flex items-center mb-1 align-middle gap-1'>
-              <h3
-                className={`font-medium text-gray-900 ${
-                  level === 0 ? 'text-xl' : 'text-base'
-                }`}
-              >
-                {label}
-              </h3>
+            <div className='flex items-center mb-3 align-middle gap-2'>
+              <h2 className='text-2xl font-bold text-gray-900'>{label}</h2>
               {isArray && (
-                <div className='text-xs text-primary-600 font-medium mr-2'>
-                  ({Array.isArray(value) ? value.length : 0})
+                <div className='text-sm text-primary-600 font-medium bg-primary-50 px-2.5 py-1 rounded-md'>
+                  {Array.isArray(value) ? value.length : 0}
                 </div>
               )}
             </div>
-            <div className={`${level > 0 ? 'ml-2 mt-4' : 'mt-4'}`}>
-              <LegislativeDetailSection data={value} level={level + 1} />
+            <div className='mt-4'>
+              <LegislativeDetailSection
+                data={value}
+                level={level + 1}
+                sectionKey={key}
+              />
             </div>
           </div>
         );

--- a/src/pages/government/legislative/senate-committees.tsx
+++ b/src/pages/government/legislative/senate-committees.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo } from 'react';
-import { SearchIcon, BookOpenIcon } from 'lucide-react';
+import { SearchIcon, BookOpenIcon, UsersIcon } from 'lucide-react';
 import legislativeData from '../../../data/directory/legislative.json';
+import { Card, CardHeader, CardContent } from '../../../components/ui/CardList';
 
 interface Committee {
   committee: string;
@@ -31,22 +32,22 @@ export default function SenateCommitteesPage() {
   }, [committees, searchTerm]);
 
   return (
-    <div className='space-y-6'>
+    <div className='@container space-y-6'>
       <div className='flex flex-col md:flex-row md:items-center md:justify-between gap-4'>
         <div>
-          <h1 className='text-2xl font-bold text-gray-900'>
+          <h1 className='text-3xl font-bold text-gray-900'>
             Senate Committees
           </h1>
-          <p className='text-gray-800 mt-1'>
-            {committees.length} permanent committees
+          <p className='text-gray-800 mt-2'>
+            {committees.length} permanent committees in the Senate
           </p>
         </div>
 
-        <div className='relative w-full md:w-64'>
+        <div className='relative w-full md:w-72'>
           <SearchIcon className='absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400' />
           <input
             type='search'
-            placeholder='Search committees...'
+            placeholder='Search committees or chairpersons...'
             className='pl-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
             value={searchTerm}
             onChange={e => setSearchTerm(e.target.value)}
@@ -65,26 +66,28 @@ export default function SenateCommitteesPage() {
           <p className='text-gray-800'>Try adjusting your search term.</p>
         </div>
       ) : (
-        <div className='grid grid-cols-1 md:grid-cols-2 gap-4'>
+        <div className='grid grid-cols-1 @lg:grid-cols-2 @3xl:grid-cols-3 gap-6'>
           {filteredCommittees.map((committee: Committee, index) => (
-            <div
-              key={index}
-              className='bg-white rounded-lg border overflow-hidden'
-            >
-              <div className='p-4'>
-                <h3 className='font-medium text-gray-900 mb-2'>
+            <Card key={index} hover={true} className='h-full flex flex-col'>
+              <CardHeader className='flex-none'>
+                <h3 className='font-semibold text-base text-gray-900 leading-snug line-clamp-2 min-h-[2.5rem]'>
                   {committee.committee}
                 </h3>
-                <div className='flex items-start'>
-                  <div className='bg-primary-50 text-primary-700 text-xs font-medium px-2 py-1 rounded-md'>
-                    Chairperson
+              </CardHeader>
+              <CardContent className='flex-1 flex flex-col justify-between'>
+                <div className='flex items-center gap-2 text-sm'>
+                  <UsersIcon className='h-4 w-4 text-gray-400 flex-shrink-0' />
+                  <div className='flex flex-col'>
+                    <span className='text-xs font-medium text-gray-500 uppercase tracking-wide'>
+                      Chairperson
+                    </span>
+                    <span className='font-medium text-gray-900 mt-0.5'>
+                      {committee.chairperson}
+                    </span>
                   </div>
-                  <p className='ml-2 text-sm text-gray-700'>
-                    {committee.chairperson}
-                  </p>
                 </div>
-              </div>
-            </div>
+              </CardContent>
+            </Card>
           ))}
         </div>
       )}


### PR DESCRIPTION
### What we changed

- Redesigned Senate Committees (senate-committees.tsx) and Chamber Detail ([chamber].tsx) pages from basic list layouts to modern card-based grids using the existing Card component system.

### What We Did

- Senate Committees: Replaced simple 2-column divs with Card, CardHeader, and CardContent components in a responsive 3-column grid (1→2→3 cols)
- Enhanced section headers with larger typography (text-2xl font-bold) and styled count badges with primary color backgrounds

### Why It's Better

- The card-based layout dramatically improves content scannability and visual consistency across the legislative section. Fixed card heights prevent layout shifting, while the responsive grid ensures optimal viewing on all devices. The unified design pattern matches the existing departments and constitutional pages, creating a cohesive user experience throughout the government portal.

**Before**
<img width="1553" height="999" alt="Screenshot 2025-10-02 at 21 09 23" src="https://github.com/user-attachments/assets/bfac3324-e5b2-4aa2-a42f-e0ca214cca22" />
<img width="1553" height="999" alt="Screenshot 2025-10-02 at 21 09 58" src="https://github.com/user-attachments/assets/e3b5d988-cef1-4db9-99cf-0cff8cd06a1a" />

**After**
<img width="1553" height="999" alt="Screenshot 2025-10-02 at 21 09 33" src="https://github.com/user-attachments/assets/db2a7b47-4215-4f23-bb57-7f940b48d4bb" />
<img width="1553" height="999" alt="Screenshot 2025-10-02 at 21 09 47" src="https://github.com/user-attachments/assets/b1543cd7-79bb-435a-8f74-1791058b249e" />
