### PR TITLE
fix(navbar): hover area when hovering

### DIFF
--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -71,13 +71,13 @@ const Navbar: React.FC = () => {
           <div className='flex items-center space-x-4'>
             <Link
               to='/join-us'
-              className='text-xs text-primary-600 hover:text-primary-700 font-semibold transition-colors'
+              className='text-xs leading-12 text-primary-600 hover:text-primary-700 font-semibold transition-colors'
             >
               🚀 Join Us
             </Link>
             <a
               href='https://www.gov.ph'
-              className='text-xs text-gray-800 hover:text-primary-600 transition-colors'
+              className='text-xs leading-12 text-gray-800 hover:text-primary-600 transition-colors'
               target='_blank'
               rel='noreferrer'
             >
@@ -86,7 +86,7 @@ const Navbar: React.FC = () => {
 
             <Link
               to='/philippines/hotlines'
-              className='text-xs text-gray-800 hover:text-primary-600 transition-colors'
+              className='text-xs leading-12 text-gray-800 hover:text-primary-600 transition-colors'
             >
               Hotlines
             </Link>
@@ -127,7 +127,7 @@ const Navbar: React.FC = () => {
           </div>
 
           {/* Desktop navigation */}
-          <div className='hidden lg:flex items-center space-x-8 pr-24'>
+          <div className='hidden lg:flex items-center space-x-8 pr-24 lg:leading-10'>
             {mainNavigation.map(item => {
               const isActive = isActiveRoute(item.href);
               return (
@@ -158,7 +158,7 @@ const Navbar: React.FC = () => {
                   </Link>
                   {item.children && (
                     <div
-                      className={`absolute left-0 mt-2 w-56 rounded-md shadow-lg bg-white ring-1 ring-black/5 transition-all duration-200 z-50 ${
+                      className={`absolute left-0 mt-2 lg:mt-0 w-56 rounded-md shadow-lg bg-white ring-1 ring-black/5 transition-all duration-200 z-50 ${
                         hoveredDropdown === item.label
                           ? 'opacity-100 visible'
                           : 'opacity-0 invisible'


### PR DESCRIPTION
**Summary**
Adds line-height to navbar items to ensure that hover target area is big enough for large desktop screens.

**Review app**: https://bettergov-git-fix-hover-target-navbar-adobocorp.vercel.app

**Before**

https://github.com/user-attachments/assets/a103914f-8c0b-4dd2-bcf7-cb7a7ff13439

**After**

https://github.com/user-attachments/assets/d00721a5-edb1-4f2f-952d-4d344578f29d


**Other notes**

This pull request makes minor adjustments to the styling of navigation links in the `Navbar` component to improve visual consistency and alignment, primarily by adding the `leading-12` utility class and tweaking layout properties.

Styling improvements for navigation links:

* Added the `leading-12` class to the "Join Us", "Hotlines", and external "gov.ph" navigation links to ensure consistent vertical alignment and spacing. [[1]](diffhunk://#diff-3d2e5241bf2cfaf8ba89a0d1290fd3e96f80a98d17172d58ce91f54c6501c302L42-R48) [[2]](diffhunk://#diff-3d2e5241bf2cfaf8ba89a0d1290fd3e96f80a98d17172d58ce91f54c6501c302L57-R57)
* Updated the desktop navigation items to include `xl:leading-12` for better alignment on extra-large screens.

Layout adjustments:

* Removed the unnecessary `mt-2` margin from the dropdown menu container to tighten the layout and maintain consistency.