### PR TITLE
fix : make page title and holiday details dynamic with current year

### DIFF
--- a/src/pages/philippines/holidays/PublicHolidays.tsx
+++ b/src/pages/philippines/holidays/PublicHolidays.tsx
@@ -8,118 +8,148 @@ interface Holiday {
   day: string;
 }
 
-const PublicHolidays: React.FC = () => {
-  const regularHolidays: Holiday[] = [
-    { event: "New Year's Day", date: 'January 1', day: 'Wednesday' },
-    {
-      event: "Eid'l Fitr (Feast of Ramadhan)",
-      date: 'April 1',
-      day: 'Tuesday',
-    },
-    { event: 'Araw ng Kagitingan', date: 'April 9', day: 'Wednesday' },
-    { event: 'Maundy Thursday', date: 'April 17', day: 'Thursday' },
-    { event: 'Good Friday', date: 'April 18', day: 'Friday' },
-    { event: 'Labor Day', date: 'May 1', day: 'Thursday' },
-    { event: 'Eidul Adha (Feast of Sacrifice)', date: 'June 6', day: 'Friday' },
-    { event: 'Independence Day', date: 'June 12', day: 'Thursday' },
-    { event: 'National Heroes Day', date: 'August 25', day: 'Monday' },
-    { event: 'Bonifacio Day', date: 'November 30', day: 'Sunday' },
-    { event: 'Christmas Day', date: 'December 25', day: 'Thursday' },
-    { event: 'Rizal Day', date: 'December 30', day: 'Tuesday' },
-  ];
+const REGULAR_HOLIDAYS: Holiday[] = [
+  { event: "New Year's Day", date: 'January 1', day: 'Wednesday' },
+  {
+    event: "Eid'l Fitr (Feast of Ramadhan)",
+    date: 'April 1',
+    day: 'Tuesday',
+  },
+  { event: 'Araw ng Kagitingan', date: 'April 9', day: 'Wednesday' },
+  { event: 'Maundy Thursday', date: 'April 17', day: 'Thursday' },
+  { event: 'Good Friday', date: 'April 18', day: 'Friday' },
+  { event: 'Labor Day', date: 'May 1', day: 'Thursday' },
+  { event: 'Eidul Adha (Feast of Sacrifice)', date: 'June 6', day: 'Friday' },
+  { event: 'Independence Day', date: 'June 12', day: 'Thursday' },
+  { event: 'National Heroes Day', date: 'August 25', day: 'Monday' },
+  { event: 'Bonifacio Day', date: 'November 30', day: 'Sunday' },
+  { event: 'Christmas Day', date: 'December 25', day: 'Thursday' },
+  { event: 'Rizal Day', date: 'December 30', day: 'Tuesday' },
+];
 
-  const specialHolidays: Holiday[] = [
-    { event: 'Ninoy Aquino Day', date: 'August 21', day: 'Thursday' },
-    { event: "All Saints' Day", date: 'November 1', day: 'Saturday' },
-    {
-      event: 'Feast of the Immaculate Conception of Mary',
-      date: 'December 8',
-      day: 'Monday',
-    },
-    { event: 'Last Day of the Year', date: 'December 31', day: 'Wednesday' },
-    { event: 'Chinese New Year', date: 'January 29', day: 'Wednesday' },
-    { event: 'Black Saturday', date: 'April 19', day: 'Saturday' },
-    { event: 'National and Local Elections', date: 'May 12', day: 'Monday' },
-    { event: 'Christmas Eve', date: 'December 24', day: 'Wednesday' },
-    { event: "All Saints' Day Eve", date: 'October 31', day: 'Friday' },
-  ];
+const SPECIAL_HOLIDAYS: Holiday[] = [
+  { event: 'Chinese New Year', date: 'January 29', day: 'Wednesday' },
+  { event: 'Black Saturday', date: 'April 19', day: 'Saturday' },
+  { event: 'National and Local Elections', date: 'May 12', day: 'Monday' },
+  { event: 'Ninoy Aquino Day', date: 'August 21', day: 'Thursday' },
+  { event: "All Saints' Day Eve", date: 'October 31', day: 'Friday' },
+  { event: "All Saints' Day", date: 'November 1', day: 'Saturday' },
+  {
+    event: 'Feast of the Immaculate Conception of Mary',
+    date: 'December 8',
+    day: 'Monday',
+  },
+  { event: 'Christmas Eve', date: 'December 24', day: 'Wednesday' },
+  { event: 'Last Day of the Year', date: 'December 31', day: 'Wednesday' },
+];
 
-  const HolidayTable = ({
-    holidays,
-    title,
-  }: {
-    holidays: Holiday[];
-    title: string;
-  }) => (
-    <div className='mb-8'>
-      <h2 className='text-2xl font-bold text-gray-800 mb-4 flex items-center'>
-        <CalendarIcon className='mr-2 h-6 w-6 text-blue-600' />
-        {title}
-      </h2>
-      <Card className='overflow-hidden'>
-        <CardHeader className='bg-blue-50 border-b border-blue-100'>
-          <h3 className='text-lg font-semibold text-blue-800'>
-            {title} ({holidays.length})
-          </h3>
-        </CardHeader>
-        <CardContent className='p-0'>
-          <div className='overflow-x-auto'>
-            <table className='min-w-full divide-y divide-gray-200'>
-              <thead className='bg-gray-50'>
-                <tr>
-                  <th
-                    scope='col'
-                    className='px-6 py-3 text-left text-xs font-medium text-gray-800 uppercase tracking-wider'
-                  >
-                    Event
-                  </th>
-                  <th
-                    scope='col'
-                    className='px-6 py-3 text-left text-xs font-medium text-gray-800 uppercase tracking-wider'
-                  >
-                    Date
-                  </th>
-                  <th
-                    scope='col'
-                    className='px-6 py-3 text-left text-xs font-medium text-gray-800 uppercase tracking-wider'
-                  >
-                    Day
-                  </th>
+function getHolidayWithDynamicDay(
+  holiday: Holiday,
+  currentYear: number
+): Holiday {
+  const fullDate = new Date(`${holiday.date} ${currentYear}`);
+
+  const days = [
+    'Sunday',
+    'Monday',
+    'Tuesday',
+    'Wednesday',
+    'Thursday',
+    'Friday',
+    'Saturday',
+  ];
+  const dayName = days[fullDate.getDay()];
+
+  return {
+    ...holiday,
+    day: dayName,
+  };
+}
+
+const HolidayTable = ({
+  holidays,
+  title,
+}: {
+  holidays: Holiday[];
+  title: string;
+}) => (
+  <div className='mb-8'>
+    <h2 className='text-2xl font-bold text-gray-800 mb-4 flex items-center'>
+      <CalendarIcon className='mr-2 h-6 w-6 text-blue-600' />
+      {title}
+    </h2>
+    <Card className='overflow-hidden'>
+      <CardHeader className='bg-blue-50 border-b border-blue-100'>
+        <h3 className='text-lg font-semibold text-blue-800'>
+          {title} ({holidays.length})
+        </h3>
+      </CardHeader>
+      <CardContent className='p-0'>
+        <div className='overflow-x-auto'>
+          <table className='min-w-full divide-y divide-gray-200'>
+            <thead className='bg-gray-50'>
+              <tr>
+                <th
+                  scope='col'
+                  className='px-6 py-3 text-left text-xs font-medium text-gray-800 uppercase tracking-wider'
+                >
+                  Event
+                </th>
+                <th
+                  scope='col'
+                  className='px-6 py-3 text-left text-xs font-medium text-gray-800 uppercase tracking-wider'
+                >
+                  Date
+                </th>
+                <th
+                  scope='col'
+                  className='px-6 py-3 text-left text-xs font-medium text-gray-800 uppercase tracking-wider'
+                >
+                  Day
+                </th>
+              </tr>
+            </thead>
+            <tbody className='bg-white divide-y divide-gray-200'>
+              {holidays.map((holiday, index) => (
+                <tr key={index} className='hover:bg-gray-50'>
+                  <td className='px-6 py-4 whitespace-nowrap'>
+                    <div className='text-sm font-medium text-gray-900'>
+                      {holiday.event}
+                    </div>
+                  </td>
+                  <td className='px-6 py-4 whitespace-nowrap'>
+                    <div className='text-sm text-gray-900'>{holiday.date}</div>
+                  </td>
+                  <td className='px-6 py-4 whitespace-nowrap'>
+                    <span className='px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-blue-100 text-blue-800'>
+                      {holiday.day}
+                    </span>
+                  </td>
                 </tr>
-              </thead>
-              <tbody className='bg-white divide-y divide-gray-200'>
-                {holidays.map((holiday, index) => (
-                  <tr key={index} className='hover:bg-gray-50'>
-                    <td className='px-6 py-4 whitespace-nowrap'>
-                      <div className='text-sm font-medium text-gray-900'>
-                        {holiday.event}
-                      </div>
-                    </td>
-                    <td className='px-6 py-4 whitespace-nowrap'>
-                      <div className='text-sm text-gray-900'>
-                        {holiday.date}
-                      </div>
-                    </td>
-                    <td className='px-6 py-4 whitespace-nowrap'>
-                      <span className='px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-blue-100 text-blue-800'>
-                        {holiday.day}
-                      </span>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </CardContent>
-      </Card>
-    </div>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </CardContent>
+    </Card>
+  </div>
+);
+
+const PublicHolidays: React.FC = () => {
+  const currentYear = new Date().getFullYear();
+
+  const regularHolidays = REGULAR_HOLIDAYS.map(holiday =>
+    getHolidayWithDynamicDay(holiday, currentYear)
+  );
+  const specialHolidays = SPECIAL_HOLIDAYS.map(holiday =>
+    getHolidayWithDynamicDay(holiday, currentYear)
   );
 
   return (
     <div className='max-w-6xl px-4 py-8 sm:mx-auto sm:px-6 lg:px-8'>
       <div className='text-center mb-12'>
         <h1 className='text-4xl font-extrabold text-gray-900 sm:text-5xl sm:tracking-tight lg:text-6xl'>
-          Philippine Public Holidays 2025
+          Philippine Public Holidays {currentYear}
         </h1>
         <p className='mt-3 max-w-2xl mx-auto text-xl text-gray-800 sm:mt-4'>
           Official non-working holidays in the Philippines


### PR DESCRIPTION
## Summary
This PR updates the holiday page to ensure information is always accurate without requiring manual yearly updates. #385 

## Changes Made
- Minor refactor (move constant, component, outside the component)
- Page title now dynamically displays the current year (e.g., `Philippine Public Holidays 2025`).
- Holiday `day` values are computed dynamically based on the current year.
- Special non-working holidays are properly sorted for consistency.

## Before 
<img width="981" height="738" alt="image" src="https://github.com/user-attachments/assets/db8dbedc-5a17-4159-a044-39b0ecd9b681" />
<img width="994" height="630" alt="image" src="https://github.com/user-attachments/assets/d7fc554d-16e5-45a9-aa2d-c735436ba6e4" />

## After
<img width="975" height="745" alt="image" src="https://github.com/user-attachments/assets/60a8eba6-25ce-4a59-80aa-a9bd34bcead2" />

<img width="994" height="630" alt="image" src="https://github.com/user-attachments/assets/ce970aac-4d97-4809-9ae0-c2065e2bf544" />

