### PR TITLE
docs(README): add Documentation section linking to BetterGov Document site

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ Our goals include:
 - Accessibility features for users with disabilities
 - Regular updates and maintenance
 
+## Documentation
+
+For an easy-to-read overview of the project, visit the [BetterGov Docs](https://better-gov-docs.vercel.app/docs/about).
+
 ## Join Us as a Volunteer
 
 We're always looking for passionate individuals to help improve BetterGov.ph. We need volunteers with various skills:


### PR DESCRIPTION
## Added Link
- [BetterGov Docs](https://better-gov-docs.vercel.app/docs/about).
- This site pulls core docs from upstream BetterGov sync every 12hrs :
  - `README.md`
  - `CONTRIBUTING.md`
  - `CODE_OF_CONDUCT.md`
  - `TESTING.md`
  - `ABOUT.md`

  
<img width="1919" height="915" alt="image" src="https://github.com/user-attachments/assets/4df5f327-1155-40ae-9a38-7eba9dc2f5c9" />


## Impact
- Faster onboarding for new contributors
- Less time hunting for docs
- Consistent, readable documentation experience