### PR TITLE
feat: add documentation link to footer about section

### DIFF
--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -76,6 +76,7 @@ export const footerNavigation = {
       title: 'About',
       links: [
         { label: 'About the Portal', href: '/about' },
+        { label: 'Documentation', href: 'https://docs.bettergov.ph/' },
         { label: 'Project Ideas', href: '/ideas' },
         { label: 'Accessibility', href: '/accessibility' },
         { label: 'Terms of Use', href: '/terms-of-service' },


### PR DESCRIPTION
# Add Documentation Link to Footer

## Summary
Adds a "Documentation" link to the footer's "About" section for easy access to project docs.

## Changes
- Added `{ label: 'Documentation', href: 'https://docs.bettergov.ph/' }` to footer navigation
- File: `src/data/navigation.ts`
