### PR TITLE
fix(governments): scroll on main content rather than header

### DIFF
--- a/src/pages/government/GovernmentPageContainer.tsx
+++ b/src/pages/government/GovernmentPageContainer.tsx
@@ -49,15 +49,13 @@ export default function GovernmentIndexPageContainer({
   useEffect(() => {
     if (location.state?.scrollToContent) {
       const contentElement = document.getElementById('government-content');
-      if (contentElement) {
-        const yScrollOffset = -150;
-        const y =
-          contentElement.getBoundingClientRect().top +
-          window.pageYOffset +
-          yScrollOffset;
-
-        window.scrollTo({ top: y, behavior: 'smooth' });
-      }
+      setTimeout(() => {
+        if (contentElement) {
+          const yScrollOffset = -140;
+          const y = contentElement.offsetTop + yScrollOffset;
+          window.scrollTo({ top: y, behavior: 'smooth' });
+        }
+      }, 100);
     }
   }, [location]);
 
@@ -85,7 +83,7 @@ export default function GovernmentIndexPageContainer({
             <aside
               className={`${
                 sidebarOpen ? 'block' : 'hidden'
-              } md:block mb-6 md:mb-0 shrink-0`}
+              } md:block mb-6 md:mb-0 shrink-0 md:sticky md:top-[8.25rem] md:self-start`}
             >
               {sidebar}
             </aside>


### PR DESCRIPTION
close #396 

This pull request makes targeted improvements to the scrolling behavior and sidebar positioning on the government index page. The main changes are focused on enhancing user experience when navigating to content and interacting with the sidebar.

***BEFORE***
![CleanShot 2025-10-04 at 20 56 20](https://github.com/user-attachments/assets/c9e1c971-0c12-4e2f-8e16-36bf91da905a)

***AFTER***
![CleanShot 2025-10-04 at 20 53 37](https://github.com/user-attachments/assets/3fef21a1-7cbb-4bd1-8d18-5a011693d0ad)

**Scrolling behavior improvements:**

* Updated the scroll logic in `GovernmentPageContainer.tsx` to use `offsetTop` instead of `getBoundingClientRect().top` and adjusted the scroll offset from -150 to -140 for more accurate positioning. Added a 100ms delay before scrolling to ensure the content is rendered.

**Sidebar positioning enhancements:**

* Modified the sidebar `<aside>` element to use `md:sticky` and `md:top-[8.25rem]` classes, making the sidebar sticky and better aligned for medium and larger screens.