### PR TITLE
chore(docker): add hot-reloading for local development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ RUN npm run build
 # Development stage
 FROM builder AS dev
 EXPOSE 5173
-CMD ["npm", "run", "dev"]
 
 FROM nginx:alpine AS production
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ FROM builder AS dev
 
 FROM nginx:alpine AS production
 
-LABEL org.opencontainers.image.authors="volunteers@bettergov.ph,root@guerzon.net"
+LABEL org.opencontainers.image.authors="volunteers@bettergov.ph"
 LABEL org.opencontainers.image.url="https://bettergov.ph"
 LABEL org.opencontainers.image.source="https://github.com/bettergovph/bettergov"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ RUN npm run build
 
 # Development stage
 FROM builder AS dev
-EXPOSE 5173
 
 FROM nginx:alpine AS production
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,11 @@ RUN npm ci
 COPY . .
 RUN npm run build
 
+# Development stage
+FROM builder AS dev
+EXPOSE 5173
+CMD ["npm", "run", "dev"]
+
 FROM nginx:alpine AS production
 
 LABEL org.opencontainers.image.authors="volunteers@bettergov.ph,root@guerzon.net"

--- a/README.md
+++ b/README.md
@@ -99,18 +99,39 @@ docker run -d -p 8080:80 --name bettergov bettergov
 
 ### Docker Compose
 
+Docker Compose is configured for two primary use cases: local development with hot-reloading and running a production-like build.
+
+#### Local Development (with Hot-Reloading)
+
+For active development, a `dev` service is configured with hot-reloading. Changes to your source code will be reflected instantly without needing to rebuild the image.
+
 ```bash
-# Start the service
-docker-compose up
+# Start the development server
+docker-compose up dev
 
 # Start in detached mode
-docker-compose up -d
+docker-compose up -d dev
+```
+**Access the application at:** `http://localhost:5173`
 
-# Stop the service
+#### Production Build
+
+To build and run the production-like container, which serves static files via Nginx:
+
+```bash
+# Build and start the service
+docker-compose up bettergov --build
+
+# Start in detached mode
+docker-compose up -d bettergov
+```
+**Access the application at:** `http://localhost:8080`
+
+To stop any of the services:
+```bash
+# Stop the services
 docker-compose down
 ```
-
-The Dockerfile uses a multi-stage build with Node.js for building and nginx for serving the static files.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -99,39 +99,19 @@ docker run -d -p 8080:80 --name bettergov bettergov
 
 ### Docker Compose
 
-Docker Compose is configured for two primary use cases: local development with hot-reloading and running a production-like build.
-
-#### Local Development (with Hot-Reloading)
-
-For active development, a `dev` service is configured with hot-reloading. Changes to your source code will be reflected instantly without needing to rebuild the image.
+For the easiest and most consistent development experience, we recommend using Docker Compose. This method uses Docker to run the application in a controlled environment with hot-reloading enabled.
 
 ```bash
 # Start the development server
-docker-compose up dev
+docker-compose up
 
 # Start in detached mode
-docker-compose up -d dev
-```
-**Access the application at:** `http://localhost:5173`
+docker-compose up -d
 
-#### Production Build
-
-To build and run the production-like container, which serves static files via Nginx:
-
-```bash
-# Build and start the service
-docker-compose up bettergov --build
-
-# Start in detached mode
-docker-compose up -d bettergov
-```
-**Access the application at:** `http://localhost:8080`
-
-To stop any of the services:
-```bash
-# Stop the services
+# Stop the service
 docker-compose down
 ```
+**Access the application at:** `http://localhost:5173`
 
 ## Testing
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   app:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 
 services:
-  dev:
+  app:
     build:
       context: .
       target: dev
@@ -16,14 +16,3 @@ services:
     command: npm run dev
     container_name: bettergov-dev
     restart: unless-stopped
-
-  bettergov:
-    build: .
-    ports:
-      - '8080:80'
-    container_name: bettergov
-    restart: unless-stopped
-    labels:
-      - 'org.opencontainers.image.authors=guerzon@proton.me'
-      - 'org.opencontainers.image.url=https://bettergov.ph'
-      - 'org.opencontainers.image.source=https://github.com/bettergovph/bettergov'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - ./index.html:/app/index.html
       - ./vite.config.ts:/app/vite.config.ts
       - ./tsconfig.json:/app/tsconfig.json
+    command: npm run dev
     container_name: bettergov-dev
     restart: unless-stopped
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,21 @@
 version: '3.8'
 
 services:
+  dev:
+    build:
+      context: .
+      target: dev
+    ports:
+      - '5173:5173'
+    volumes:
+      - ./src:/app/src
+      - ./public:/app/public
+      - ./index.html:/app/index.html
+      - ./vite.config.ts:/app/vite.config.ts
+      - ./tsconfig.json:/app/tsconfig.json
+    container_name: bettergov-dev
+    restart: unless-stopped
+
   bettergov:
     build: .
     ports:


### PR DESCRIPTION
## Overview

This change enhances the local development workflow by introducing a dedicated development service in Docker Compose.

Previously, the Docker setup was optimized for production builds, requiring developers to rebuild the entire image to see changes. This commit introduces a new `dev` service that enables hot-reloading for a smoother development experience.

## Changes

- Adds a `dev` stage to the `Dockerfile` that uses the Vite development server
- Adds a `dev` service to `docker-compose.yml` that mounts the source code as a volume, allowing changes to be reflected instantly without rebuilding

## Usage

To use the new development environment, run:

```
docker-compose up dev
```

## Motivation

This change introduces a dedicated Docker Compose service for local development to provide a consistent, hot-reloading environment. While `npm run dev` works for individual setups, this approach is crucial for a collaborative open-source project because it:

- **Ensures Environment Consistency:** Guarantees every contributor uses the exact same Node.js version and dependencies, eliminating "it works on my machine" issues
- **Simplifies Onboarding:** Allows new volunteers to set up a complete development environment with a single command, lowering the barrier to contribution
- **Improves Dev/Prod Parity:** Aligns the development environment more closely with the production container, reducing the risk of production-only bugs