### PR TITLE
chore(ci): use playwright docker image for E2E CI

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -53,6 +53,9 @@ jobs:
   e2e_tests:
     name: Playwright Tests (Shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
     runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.55.0-noble
+      options: --user 1001
     strategy:
       fail-fast: false
       matrix:
@@ -68,9 +71,6 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
-
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium firefox webkit
 
       - name: Run E2E Tests
         run: npx playwright test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}


### PR DESCRIPTION
# Summary
- Pull playwright container instead of installing browsers each time CI is triggered
- This lessens the running time of the CI

## Related documentation
- https://playwright.dev/docs/ci#via-containers
- https://mcr.microsoft.com/en-us/artifact/mar/playwright/about

Tested on https://github.com/DaijobuDes/bettergov/actions/runs/18271862080

and compare with https://github.com/bettergovph/bettergov/actions/runs/18269457731