### PR TITLE
fix(navbar): remove shift caused by active border

### DIFF
--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -139,10 +139,10 @@ const Navbar: FC = () => {
                 >
                   <Link
                     to={item.href}
-                    className={`flex items-center font-medium transition-colors ${
+                    className={`flex items-center font-medium transition-colors pb-1 border-b-2 ${
                       isActive
-                        ? 'text-primary-600 border-b-2 border-primary-600 pb-1'
-                        : 'text-gray-700 hover:text-primary-600'
+                        ? 'text-primary-600 border-primary-600'
+                        : 'text-gray-700 hover:text-primary-600 border-transparent'
                     }`}
                   >
                     {t(`navbar.${item.label.toLowerCase()}`)}


### PR DESCRIPTION
Currently, the active navigation item in the navbar slightly shifts upward when selected. This happens because the active link adds a bottom border that isn't present on inactive links, changing the element's height.

**Fix**

To maintain consistent spacing and prevent the UI shift, I added a consistent bottom border to all navigation items:

- Inactive links now have a transparent bottom border.
- The active link retains the colored bottom border (as the visual indicator).

This ensures the navbar layout remains stable when switching between links.

**Before:**

https://github.com/user-attachments/assets/18bc3d33-4ca5-4da6-986f-76a00c218ed7

**After:**

https://github.com/user-attachments/assets/934c4594-e727-475b-8451-242395495a14

**Additional notes**

No visual regressions observed in other navbar states (hover, focus).