### PR TITLE
fix(home): adjust Join Now button and UI typography tab size

### DIFF
--- a/src/components/home/JoinUsStrip.tsx
+++ b/src/components/home/JoinUsStrip.tsx
@@ -40,7 +40,7 @@ const JoinUsStrip: FC = () => {
           <div className='flex items-center gap-3'>
             <Link
               to='/join-us'
-              className='inline-flex items-center gap-2 bg-yellow-300 text-gray-900 px-4 py-1.5 rounded-full text-sm font-semibold hover:bg-yellow-200 transition-all transform hover:scale-105'
+              className='inline-flex items-center gap-2 bg-yellow-300 text-gray-900 px-4 py-1.5 rounded-full text-sm font-semibold hover:bg-yellow-200 transition-all transform hover:scale-105 whitespace-nowrap'
             >
               {t('joinUs.joinNow')}
               <ArrowRightIcon className='h-3 w-3' />


### PR DESCRIPTION
# Pull Request: UI Fix

Currently, the "Join Now" Button is in the Tab size (min-width: 1023px). The Typography wraps around the button, but it doesn't quite look good on smaller devices.

Fix

To maintain a good-looking UI even in the smaller details. I aligned it more uniformly in the UI design for the button.

Before:
<img width="792" height="428" alt="TAB-button-issue-wrap" src="https://github.com/user-attachments/assets/e40c733b-9e87-4e50-ae2c-cc6ea5118742" />


After:
<img width="815" height="332" alt="TAB-button-fix-wrap" src="https://github.com/user-attachments/assets/cf7898ae-58d3-48e1-978b-e5e0b8b18fcd" />

## Solution

I add the _whitespace-nowrap_ at the last class attribute

```CSS
<Link to='/join-us' 
className='inline-flex items-center gap-2 bg-yellow-300 text-gray-900 
px-4 py-1.5 rounded-full text-sm font-semibold hover:bg-yellow-200 transition-all 
transform hover:scale-105 whitespace-nowrap'>
{t('joinUs.joinNow')}
              <ArrowRightIcon className='h-3 w-3' />
</Link>
```
