### PR TITLE
fix(navbar): make text links nowrap

### DIFF
--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -145,7 +145,7 @@ const Navbar: FC = () => {
                 >
                   <Link
                     to={item.href}
-                    className={`flex items-center font-medium transition-colors pb-1 border-b-2 ${
+                    className={`flex items-center font-medium transition-colors pb-1 border-b-2 whitespace-nowrap ${
                       isActive
                         ? 'text-primary-600 border-primary-600'
                         : 'text-gray-700 hover:text-primary-600 border-transparent'


### PR DESCRIPTION
issue: 
<img width="2642" height="1076" alt="CleanShot 2025-10-08 at 15 39 23@2x" src="https://github.com/user-attachments/assets/9c6c573a-15dc-48a2-b187-2b6c7b49b6a5" />


after:
<img width="2768" height="1150" alt="CleanShot 2025-10-08 at 15 39 54@2x" src="https://github.com/user-attachments/assets/52f360a6-dbd8-4e6c-a755-861b35604ce0" />
 