### PR TITLE
chore: Change the Test Selector for the Logo and Site Name

### DIFF
--- a/e2e/homepage.spec.ts
+++ b/e2e/homepage.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 test.describe('Homepage', () => {
   test('should load and display main elements', async ({ page }) => {
@@ -11,7 +11,9 @@ test.describe('Homepage', () => {
     await expect(page.locator('nav')).toBeVisible();
 
     // Check logo and site name
-    await expect(page.getByText('BetterGov.ph').first()).toBeVisible();
+    await expect(
+      page.getByRole('link', { name: /BetterGov Logo BetterGov.ph/i })
+    ).toBeVisible();
 
     // Check hero section
     await expect(


### PR DESCRIPTION
## Overview

The e2e tests we're failing in mobile when a span was added ([here](https://github.com/bettergovph/bettergov/blob/1cff78d5a84669a24682334a704d8d0bf4e24a43/src/components/layout/Navbar.tsx#L82)). This is not causing a test failure for desktop or tablet, since the span is only hidden in mobile.

<img width="590" height="90" alt="Screenshot 2025-10-09 at 12 25 13 AM" src="https://github.com/user-attachments/assets/4d544dd6-d300-4277-a193-72120de7bb6f" />


## Changes

Changed the selector for the failing tests to `page.getByRole('link', { name: /BetterGov Logo BetterGov.ph/i })` since the comment above it aims to assert the visibility of the logo and site name.

If this solution is not ideal, happy to revise it otherwise.

Other solutions I can think of:

1. Add a `data-testid="site-name"` to the `<div>`.
2. Change the element from `<div>` to `<h1>`. I tried this, but more tests fail due to locators resolving to multiple elements.

## Testing

_Run tests locally and make sure they passed._

<img width="216" height="43" alt="Screenshot 2025-10-09 at 12 13 45 AM" src="https://github.com/user-attachments/assets/170321b1-07ec-4fd9-b995-3437196aa006" />
