### PR TITLE
fix: (Navbar) Overlapping and Overflowing Navbar Content

### DIFF
--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -133,7 +133,7 @@ const Navbar: FC = () => {
           </div>
 
           {/* Desktop navigation */}
-          <div className='hidden lg:flex items-center space-x-8 pr-24 lg:leading-10'>
+          <div className='hidden lg:flex items-center lg:space-x-4 xl:space-x-8 lg:pr-6 xl:pr-24 lg:leading-10'>
             {mainNavigation.map(item => {
               const isActive = isActiveRoute(item.href);
               return (


### PR DESCRIPTION
## Overview

This PR resolves #443 by making sure that the Navbar contents are being displayed properly.

## Changes

Making the spacing between the contents tighter for `lg` screen width.

> [!NOTE]
> 
> This might not be the best solution because it made the contents of the Navbar look suffocating. Another solution I can think of is to start displaying the desktop Navbar elements in `xl:` breakpoint. But in that case, we'll be having a lot of whitespace when in `lg` screen width.
> 
> I'm open to others' opinions on how we might approach this better.

## Testing

Tested locally.

_Navbar contents are not overlapping and overflowing anymore._

<img width="887" height="213" alt="Screenshot 2025-10-11 at 1 47 06 AM" src="https://github.com/user-attachments/assets/9a22b17f-0510-4484-8ad5-191c862cc834" />
