### PR TITLE
fix: Sync TypeScript version format in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
         "tailwindcss": "^4.1.13",
         "ts-node": "^10.9.2",
         "tsx": "^4.20.5",
-        "typescript": "5.5.3",
+        "typescript": "^5.5.3",
         "typescript-eslint": "^8.3.0",
         "uuid": "^9.0.1",
         "vite": "^5.4.2"


### PR DESCRIPTION
## Summary
- Fixed TypeScript version inconsistency between `package.json` and `package-lock.json`
- Changed from `5.5.3` to `^5.5.3` in lockfile to match package.json

## Context
I think the `package-lock.json` had an exact version (`5.5.3`) while `package.json` specifies a caret range (`^5.5.3`). This causes `npm install` to regenerate the lockfile on every run, creating unnecessary git changes.

## Test plan
- [x] Run `npm install` and verify no changes to package-lock.json