### PR TITLE
fix: closing modal does not clear the country parameter in URL

### DIFF
--- a/src/pages/travel/visa/index.tsx
+++ b/src/pages/travel/visa/index.tsx
@@ -268,7 +268,9 @@ const VISA_REQUIRED_COUNTRIES: Country[] = [
 const VisaPage: FC = () => {
   const { t } = useTranslation('visa');
   const [searchTerm, setSearchTerm] = useState<string>('');
-  const [selectedCountry, setSelectedCountry] = useQueryState('country');
+  const [selectedCountry, setSelectedCountry] = useQueryState('country', {
+    clearOnDefault: true,
+  });
   const [viewMode, setViewMode] = useQueryState('view');
   const [visaRequirement, setVisaRequirement] =
     useState<VisaRequirement | null>(null);
@@ -396,6 +398,7 @@ const VisaPage: FC = () => {
 
   const closeDetailsDialog = () => {
     setDialogOpen(false);
+    setSelectedCountry(null);
   };
 
   const handleCheckVisaRequirements = () => {


### PR DESCRIPTION
Since the modal opens based on the country parameter in the URL, it should also be removed when the modal is closed.