### PR TITLE
feat: add hotline reporting feature with modal and API endpoint

### DIFF
--- a/functions/api/crawl.ts
+++ b/functions/api/crawl.ts
@@ -106,7 +106,6 @@ async function checkRateLimit(env: Env, clientIP: string): Promise<boolean> {
 export async function onRequest(context: {
   request: Request;
   env: Env;
-  ctx: ExecutionContext;
 }): Promise<Response> {
   const { request, env } = context;
 

--- a/functions/api/crawl.ts
+++ b/functions/api/crawl.ts
@@ -106,7 +106,7 @@ async function checkRateLimit(env: Env, clientIP: string): Promise<boolean> {
 export async function onRequest(context: {
   request: Request;
   env: Env;
-  params: Record<string, string>;
+  ctx: ExecutionContext;
 }): Promise<Response> {
   const { request, env } = context;
 

--- a/functions/api/report-hotline.ts
+++ b/functions/api/report-hotline.ts
@@ -1,0 +1,231 @@
+import { Env } from '../types';
+
+interface ReportHotlineRequest {
+  hotlineName: string;
+  issue: string;
+  correctInfo?: string;
+  source?: string;
+  reporterEmail?: string;
+}
+
+export async function onRequest(context: {
+  request: Request;
+  env: Env;
+  ctx: ExecutionContext;
+}): Promise<Response> {
+  const { request, env } = context;
+
+  // Only allow POST requests
+  if (request.method !== 'POST') {
+    return new Response(
+      JSON.stringify({ error: 'Method not allowed. Use POST.' }),
+      {
+        status: 405,
+        headers: { 'Content-Type': 'application/json' },
+      }
+    );
+  }
+
+  // Validate Content-Type header
+  const contentType = request.headers.get('content-type');
+  if (!contentType || !contentType.includes('application/json')) {
+    return new Response(
+      JSON.stringify({
+        error: 'Unsupported Media Type. Content-Type must be application/json',
+      }),
+      {
+        status: 415,
+        headers: { 'Content-Type': 'application/json' },
+      }
+    );
+  }
+
+  // Parse JSON body with error handling
+  let data: ReportHotlineRequest;
+  try {
+    data = await request.json();
+  } catch (parseError) {
+    return new Response(
+      JSON.stringify({
+        error: 'Invalid JSON in request body',
+        message:
+          parseError instanceof Error
+            ? parseError.message
+            : 'JSON parse failed',
+      }),
+      {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      }
+    );
+  }
+
+  try {
+    // Validate required fields
+    if (!data.hotlineName || !data.issue) {
+      return new Response(
+        JSON.stringify({
+          error: 'Missing required fields: hotlineName and issue are required',
+        }),
+        {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      );
+    }
+
+    // Create GitHub issue via API
+    const githubToken = env.GITHUB_TOKEN;
+    if (!githubToken) {
+      return new Response(
+        JSON.stringify({
+          error: 'GitHub integration not configured',
+          fallback:
+            'Please report directly at https://github.com/bettergovph/bettergov/issues/new',
+        }),
+        {
+          status: 503,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      );
+    }
+
+    // Log reporter email server-side only (not in public issue)
+    if (data.reporterEmail) {
+      console.log(
+        `[Report Contact Info] Issue for hotline "${data.hotlineName}" - Contact: ${data.reporterEmail}`
+      );
+    }
+
+    // Construct issue body (NO PII included)
+    const issueBody = `## Hotline Information Issue
+
+### Which hotline has outdated information?
+${data.hotlineName}
+
+### What is incorrect?
+${data.issue}
+
+${data.correctInfo ? `### What should it be?\n${data.correctInfo}\n\n` : ''}
+${data.source ? `### Source\n${data.source}\n\n` : ''}
+---
+Reported via API from: /philippines/hotlines
+Timestamp: ${new Date().toISOString()}`;
+
+    // Create GitHub issue
+    const githubResponse = await fetch(
+      'https://api.github.com/repos/bettergovph/bettergov/issues',
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${githubToken}`,
+          'Content-Type': 'application/json',
+          'User-Agent': 'BetterGov-Hotline-Reporter',
+          Accept: 'application/vnd.github.v3+json',
+        },
+        body: JSON.stringify({
+          title: `Outdated Hotline: ${data.hotlineName}`,
+          body: issueBody,
+          labels: ['hotline', 'data-update', 'user-report'],
+        }),
+      }
+    );
+
+    if (!githubResponse.ok) {
+      const errorText = await githubResponse.text();
+      // Log detailed error server-side for debugging
+      console.error(
+        `GitHub API error (status ${githubResponse.status}):`,
+        errorText
+      );
+      // Return generic error to client without exposing sensitive details
+      return new Response(
+        JSON.stringify({
+          error: 'Failed to create GitHub issue',
+        }),
+        {
+          status: githubResponse.status,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      );
+    }
+
+    const githubData: unknown = await githubResponse.json();
+
+    // Runtime validation of GitHub response
+    if (
+      !githubData ||
+      typeof githubData !== 'object' ||
+      !('html_url' in githubData) ||
+      !('number' in githubData) ||
+      typeof githubData.html_url !== 'string' ||
+      typeof githubData.number !== 'number'
+    ) {
+      console.error(
+        'Invalid GitHub API response structure:',
+        JSON.stringify(githubData)
+      );
+      return new Response(
+        JSON.stringify({
+          error: 'Failed to create GitHub issue',
+          message: 'Invalid response from GitHub API',
+        }),
+        {
+          status: 500,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      );
+    }
+
+    const issue = {
+      html_url: githubData.html_url,
+      number: githubData.number,
+    };
+
+    // If email provided, store it as server-side metadata (accessible via logs)
+    // This keeps PII out of the public GitHub issue
+    if (data.reporterEmail) {
+      console.log(
+        `[Contact Metadata] GitHub Issue #${issue.number} - Reporter: ${data.reporterEmail}`
+      );
+    }
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        message: 'Report submitted successfully',
+        issueUrl: issue.html_url,
+        issueNumber: issue.number,
+      }),
+      {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      }
+    );
+  } catch (error) {
+    // Log full error with stack trace to server console
+    console.error('Error processing report:', error);
+    if (error instanceof Error && error.stack) {
+      console.error('Stack trace:', error.stack);
+    }
+
+    // Return sanitized error message based on environment
+    const isProduction = env.NODE_ENV === 'production';
+    const errorMessage = isProduction
+      ? 'Internal server error'
+      : error instanceof Error
+        ? error.message
+        : 'Unknown error';
+
+    return new Response(
+      JSON.stringify({
+        error: 'Failed to process report',
+        message: errorMessage,
+      }),
+      {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      }
+    );
+  }
+}

--- a/functions/api/report-hotline.ts
+++ b/functions/api/report-hotline.ts
@@ -74,105 +74,116 @@ export async function onRequest(context: {
       );
     }
 
+    // Check for GitHub token
+    const githubToken = env.GITHUB_TOKEN;
+    if (!githubToken) {
+      return new Response(
+        JSON.stringify({
+          error: 'GitHub integration not configured',
+          message: 'Please contact the maintainers to report this issue',
+        }),
+        {
+          status: 503,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      );
+    }
+
     // Log report submission (no PII in logs)
     console.log(
-      `[Report Submission] Received report for hotline: "${data.hotlineName}"`
+      `[Report Submission] Creating GitHub issue for hotline: "${data.hotlineName}"`
     );
 
-    // Construct email body
-    const emailBody = `
-New Hotline Report Submission
-=============================
+    // Construct GitHub issue body (no PII in public issue)
+    const issueBody = `## Hotline Information Issue
 
-Hotline Name: ${data.hotlineName}
+### Which hotline has outdated information?
+${data.hotlineName}
 
-What is incorrect:
+### What is incorrect?
 ${data.issue}
 
-${data.correctInfo ? `What should it be:\n${data.correctInfo}\n\n` : ''}
-${data.source ? `Source:\n${data.source}\n\n` : ''}
-${data.reporterEmail ? `Reporter Email: ${data.reporterEmail}\n\n` : ''}
+${data.correctInfo ? `### What should it be?\n${data.correctInfo}\n\n` : ''}
+${data.source ? `### Source\n${data.source}\n\n` : ''}
 ---
-Reported from: /philippines/hotlines
+Reported via community form from: /philippines/hotlines
 Timestamp: ${new Date().toISOString()}
-    `.trim();
 
-    // Send email using Cloudflare Email Workers (MailChannels)
-    // This is a free service available on Cloudflare Workers
-    const emailPayload = {
-      personalizations: [
-        {
-          to: [{ email: 'bugs@bettergov.ph', name: 'BetterGov Team' }],
-        },
-      ],
-      from: {
-        email: 'noreply@bettergov.ph',
-        name: 'BetterGov Hotline Reporter',
-      },
-      subject: `Hotline Report: ${data.hotlineName}`,
-      content: [
-        {
-          type: 'text/plain',
-          value: emailBody,
-        },
-      ],
-    };
+${data.reporterEmail ? `\n<!-- Reporter contact (private): ${data.reporterEmail} -->` : ''}`;
 
-    // Try to send email via MailChannels (free on Cloudflare Workers)
+    // Create GitHub issue
     try {
-      const emailResponse = await fetch(
-        'https://api.mailchannels.net/tx/v1/send',
+      const githubResponse = await fetch(
+        'https://api.github.com/repos/bettergovph/bettergov/issues',
         {
           method: 'POST',
           headers: {
+            Authorization: `Bearer ${githubToken}`,
             'Content-Type': 'application/json',
+            'User-Agent': 'BetterGov-Hotline-Reporter',
+            Accept: 'application/vnd.github.v3+json',
           },
-          body: JSON.stringify(emailPayload),
+          body: JSON.stringify({
+            title: `Outdated Hotline: ${data.hotlineName}`,
+            body: issueBody,
+            labels: ['hotline', 'data-update', 'community-report'],
+          }),
         }
       );
 
-      if (!emailResponse.ok) {
-        const errorText = await emailResponse.text();
+      if (!githubResponse.ok) {
+        const errorText = await githubResponse.text();
         console.error(
-          `Email sending failed (status ${emailResponse.status}):`,
+          `GitHub API error (status ${githubResponse.status}):`,
           errorText
         );
-        // Don't fail the request - just log it
-        console.log(
-          '[Fallback] Report logged to console for manual processing'
+        return new Response(
+          JSON.stringify({
+            error: 'Failed to create GitHub issue',
+            message: 'Please try again or contact the maintainers',
+          }),
+          {
+            status: githubResponse.status,
+            headers: { 'Content-Type': 'application/json' },
+          }
         );
-      } else {
-        console.log('[Report Success] Email sent successfully');
       }
-    } catch (emailError) {
-      console.error('Email sending error:', emailError);
-      console.log('[Fallback] Report logged to console for manual processing');
+
+      const githubData: { html_url: string; number: number } =
+        await githubResponse.json();
+
+      console.log(
+        `[Report Success] GitHub Issue #${githubData.number} created for hotline: "${data.hotlineName}"`
+      );
+
+      return new Response(
+        JSON.stringify({
+          success: true,
+          message: 'Report submitted successfully',
+          issueUrl: githubData.html_url,
+          issueNumber: githubData.number,
+        }),
+        {
+          status: 201,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      );
+    } catch (githubError) {
+      console.error('GitHub API error:', githubError);
+      return new Response(
+        JSON.stringify({
+          error: 'Failed to create GitHub issue',
+          message:
+            githubError instanceof Error
+              ? githubError.message
+              : 'Unknown error',
+        }),
+        {
+          status: 500,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      );
     }
-
-    // Always log the full report to console for backup
-    console.log(
-      '[Report Details]',
-      JSON.stringify({
-        hotlineName: data.hotlineName,
-        issue: data.issue,
-        correctInfo: data.correctInfo,
-        source: data.source,
-        hasEmail: !!data.reporterEmail,
-        timestamp: new Date().toISOString(),
-      })
-    );
-
-    // Return success to user regardless of email status
-    return new Response(
-      JSON.stringify({
-        success: true,
-        message: 'Report submitted successfully',
-      }),
-      {
-        status: 201,
-        headers: { 'Content-Type': 'application/json' },
-      }
-    );
   } catch (error) {
     // Log full error with stack trace to server console
     console.error('Error processing report:', error);

--- a/functions/api/report-hotline.ts
+++ b/functions/api/report-hotline.ts
@@ -90,12 +90,10 @@ export async function onRequest(context: {
       );
     }
 
-    // Log reporter email server-side only (not in public issue)
-    if (data.reporterEmail) {
-      console.log(
-        `[Report Contact Info] Issue for hotline "${data.hotlineName}" - Contact: ${data.reporterEmail}`
-      );
-    }
+    // Log report submission (no PII)
+    console.log(
+      `[Report Submission] Creating issue for hotline: "${data.hotlineName}"`
+    );
 
     // Construct issue body (NO PII included)
     const issueBody = `## Hotline Information Issue
@@ -112,24 +110,64 @@ ${data.source ? `### Source\n${data.source}\n\n` : ''}
 Reported via API from: /philippines/hotlines
 Timestamp: ${new Date().toISOString()}`;
 
-    // Create GitHub issue
-    const githubResponse = await fetch(
-      'https://api.github.com/repos/bettergovph/bettergov/issues',
-      {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${githubToken}`,
-          'Content-Type': 'application/json',
-          'User-Agent': 'BetterGov-Hotline-Reporter',
-          Accept: 'application/vnd.github.v3+json',
-        },
-        body: JSON.stringify({
-          title: `Outdated Hotline: ${data.hotlineName}`,
-          body: issueBody,
-          labels: ['hotline', 'data-update', 'user-report'],
-        }),
+    // Create GitHub issue with timeout handling
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 10000); // 10s timeout
+
+    let githubResponse: Response;
+    try {
+      githubResponse = await fetch(
+        'https://api.github.com/repos/bettergovph/bettergov/issues',
+        {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${githubToken}`,
+            'Content-Type': 'application/json',
+            'User-Agent': 'BetterGov-Hotline-Reporter',
+            Accept: 'application/vnd.github.v3+json',
+          },
+          body: JSON.stringify({
+            title: `Outdated Hotline: ${data.hotlineName}`,
+            body: issueBody,
+            labels: ['hotline', 'data-update', 'user-report'],
+          }),
+          signal: controller.signal,
+        }
+      );
+    } catch (fetchError) {
+      clearTimeout(timeoutId);
+
+      // Handle abort/timeout error
+      if (fetchError instanceof Error && fetchError.name === 'AbortError') {
+        console.error('GitHub API request timed out');
+        return new Response(
+          JSON.stringify({
+            error: 'Request timed out',
+            message: 'GitHub API did not respond in time',
+          }),
+          {
+            status: 504,
+            headers: { 'Content-Type': 'application/json' },
+          }
+        );
       }
-    );
+
+      // Handle other fetch errors (network issues, etc.)
+      console.error('GitHub API fetch error:', fetchError);
+      return new Response(
+        JSON.stringify({
+          error: 'Failed to connect to GitHub',
+          message:
+            fetchError instanceof Error ? fetchError.message : 'Network error',
+        }),
+        {
+          status: 503,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      );
+    } finally {
+      clearTimeout(timeoutId);
+    }
 
     if (!githubResponse.ok) {
       const errorText = await githubResponse.text();
@@ -182,13 +220,10 @@ Timestamp: ${new Date().toISOString()}`;
       number: githubData.number,
     };
 
-    // If email provided, store it as server-side metadata (accessible via logs)
-    // This keeps PII out of the public GitHub issue
-    if (data.reporterEmail) {
-      console.log(
-        `[Contact Metadata] GitHub Issue #${issue.number} - Reporter: ${data.reporterEmail}`
-      );
-    }
+    // Log successful issue creation (no PII)
+    console.log(
+      `[Report Success] GitHub Issue #${issue.number} created for hotline: "${data.hotlineName}"`
+    );
 
     return new Response(
       JSON.stringify({

--- a/functions/api/report-hotline.ts
+++ b/functions/api/report-hotline.ts
@@ -74,163 +74,99 @@ export async function onRequest(context: {
       );
     }
 
-    // Create GitHub issue via API
-    const githubToken = env.GITHUB_TOKEN;
-    if (!githubToken) {
-      return new Response(
-        JSON.stringify({
-          error: 'GitHub integration not configured',
-          fallback:
-            'Please report directly at https://github.com/bettergovph/bettergov/issues/new',
-        }),
-        {
-          status: 503,
-          headers: { 'Content-Type': 'application/json' },
-        }
-      );
-    }
-
-    // Log report submission (no PII)
+    // Log report submission (no PII in logs)
     console.log(
-      `[Report Submission] Creating issue for hotline: "${data.hotlineName}"`
+      `[Report Submission] Received report for hotline: "${data.hotlineName}"`
     );
 
-    // Construct issue body (NO PII included)
-    const issueBody = `## Hotline Information Issue
+    // Construct email body
+    const emailBody = `
+New Hotline Report Submission
+=============================
 
-### Which hotline has outdated information?
-${data.hotlineName}
+Hotline Name: ${data.hotlineName}
 
-### What is incorrect?
+What is incorrect:
 ${data.issue}
 
-${data.correctInfo ? `### What should it be?\n${data.correctInfo}\n\n` : ''}
-${data.source ? `### Source\n${data.source}\n\n` : ''}
+${data.correctInfo ? `What should it be:\n${data.correctInfo}\n\n` : ''}
+${data.source ? `Source:\n${data.source}\n\n` : ''}
+${data.reporterEmail ? `Reporter Email: ${data.reporterEmail}\n\n` : ''}
 ---
-Reported via API from: /philippines/hotlines
-Timestamp: ${new Date().toISOString()}`;
+Reported from: /philippines/hotlines
+Timestamp: ${new Date().toISOString()}
+    `.trim();
 
-    // Create GitHub issue with timeout handling
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 10000); // 10s timeout
+    // Send email using Cloudflare Email Workers (MailChannels)
+    // This is a free service available on Cloudflare Workers
+    const emailPayload = {
+      personalizations: [
+        {
+          to: [{ email: 'bugs@bettergov.ph', name: 'BetterGov Team' }],
+        },
+      ],
+      from: {
+        email: 'noreply@bettergov.ph',
+        name: 'BetterGov Hotline Reporter',
+      },
+      subject: `Hotline Report: ${data.hotlineName}`,
+      content: [
+        {
+          type: 'text/plain',
+          value: emailBody,
+        },
+      ],
+    };
 
-    let githubResponse: Response;
+    // Try to send email via MailChannels (free on Cloudflare Workers)
     try {
-      githubResponse = await fetch(
-        'https://api.github.com/repos/bettergovph/bettergov/issues',
+      const emailResponse = await fetch(
+        'https://api.mailchannels.net/tx/v1/send',
         {
           method: 'POST',
           headers: {
-            Authorization: `Bearer ${githubToken}`,
             'Content-Type': 'application/json',
-            'User-Agent': 'BetterGov-Hotline-Reporter',
-            Accept: 'application/vnd.github.v3+json',
           },
-          body: JSON.stringify({
-            title: `Outdated Hotline: ${data.hotlineName}`,
-            body: issueBody,
-            labels: ['hotline', 'data-update', 'user-report'],
-          }),
-          signal: controller.signal,
+          body: JSON.stringify(emailPayload),
         }
       );
-    } catch (fetchError) {
-      clearTimeout(timeoutId);
 
-      // Handle abort/timeout error
-      if (fetchError instanceof Error && fetchError.name === 'AbortError') {
-        console.error('GitHub API request timed out');
-        return new Response(
-          JSON.stringify({
-            error: 'Request timed out',
-            message: 'GitHub API did not respond in time',
-          }),
-          {
-            status: 504,
-            headers: { 'Content-Type': 'application/json' },
-          }
+      if (!emailResponse.ok) {
+        const errorText = await emailResponse.text();
+        console.error(
+          `Email sending failed (status ${emailResponse.status}):`,
+          errorText
         );
+        // Don't fail the request - just log it
+        console.log(
+          '[Fallback] Report logged to console for manual processing'
+        );
+      } else {
+        console.log('[Report Success] Email sent successfully');
       }
-
-      // Handle other fetch errors (network issues, etc.)
-      console.error('GitHub API fetch error:', fetchError);
-      return new Response(
-        JSON.stringify({
-          error: 'Failed to connect to GitHub',
-          message:
-            fetchError instanceof Error ? fetchError.message : 'Network error',
-        }),
-        {
-          status: 503,
-          headers: { 'Content-Type': 'application/json' },
-        }
-      );
-    } finally {
-      clearTimeout(timeoutId);
+    } catch (emailError) {
+      console.error('Email sending error:', emailError);
+      console.log('[Fallback] Report logged to console for manual processing');
     }
 
-    if (!githubResponse.ok) {
-      const errorText = await githubResponse.text();
-      // Log detailed error server-side for debugging
-      console.error(
-        `GitHub API error (status ${githubResponse.status}):`,
-        errorText
-      );
-      // Return generic error to client without exposing sensitive details
-      return new Response(
-        JSON.stringify({
-          error: 'Failed to create GitHub issue',
-        }),
-        {
-          status: githubResponse.status,
-          headers: { 'Content-Type': 'application/json' },
-        }
-      );
-    }
-
-    const githubData: unknown = await githubResponse.json();
-
-    // Runtime validation of GitHub response
-    if (
-      !githubData ||
-      typeof githubData !== 'object' ||
-      !('html_url' in githubData) ||
-      !('number' in githubData) ||
-      typeof githubData.html_url !== 'string' ||
-      typeof githubData.number !== 'number'
-    ) {
-      console.error(
-        'Invalid GitHub API response structure:',
-        JSON.stringify(githubData)
-      );
-      return new Response(
-        JSON.stringify({
-          error: 'Failed to create GitHub issue',
-          message: 'Invalid response from GitHub API',
-        }),
-        {
-          status: 500,
-          headers: { 'Content-Type': 'application/json' },
-        }
-      );
-    }
-
-    const issue = {
-      html_url: githubData.html_url,
-      number: githubData.number,
-    };
-
-    // Log successful issue creation (no PII)
+    // Always log the full report to console for backup
     console.log(
-      `[Report Success] GitHub Issue #${issue.number} created for hotline: "${data.hotlineName}"`
+      '[Report Details]',
+      JSON.stringify({
+        hotlineName: data.hotlineName,
+        issue: data.issue,
+        correctInfo: data.correctInfo,
+        source: data.source,
+        hasEmail: !!data.reporterEmail,
+        timestamp: new Date().toISOString(),
+      })
     );
 
+    // Return success to user regardless of email status
     return new Response(
       JSON.stringify({
         success: true,
         message: 'Report submitted successfully',
-        issueUrl: issue.html_url,
-        issueNumber: issue.number,
       }),
       {
         status: 201,

--- a/functions/index.ts
+++ b/functions/index.ts
@@ -10,22 +10,35 @@ import {
 import { onRequest as crawlRequest } from './api/crawl';
 import { onRequest as weatherKVRequest } from './weather';
 import { onRequest as forexKVRequest } from './forex';
+import { onRequest as reportHotlineRequest } from './api/report-hotline';
 import { Env } from './types';
 
 // Export the scheduled handlers
 export { scheduled as scheduled_getWeather } from './api/weather';
 export { scheduled as scheduled_getForex } from './api/forex';
 
+// Helper function to add CORS headers to a response
+function addCorsHeaders(
+  response: Response,
+  corsHeaders: Record<string, string>
+): Response {
+  const newHeaders = new Headers(response.headers);
+  Object.keys(corsHeaders).forEach(key => {
+    newHeaders.set(key, corsHeaders[key]);
+  });
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: newHeaders,
+  });
+}
+
 // Handler for HTTP requests
 export default {
-  async scheduled(
-    controller: ScheduledController,
-    env: Env,
-    ctx: ExecutionContext
-  ): Promise<void> {
+  async scheduled(controller: ScheduledController, env: Env): Promise<void> {
     console.log('Scheduled update');
-    await getWeatherScheduled(controller, env, ctx);
-    await getForexScheduled(controller, env, ctx);
+    await getWeatherScheduled(controller, env);
+    await getForexScheduled(controller, env);
   },
 
   async fetch(
@@ -39,7 +52,7 @@ export default {
     // Add CORS headers to all responses
     const corsHeaders: Record<string, string> = {
       'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Methods': 'GET, OPTIONS',
+      'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
       'Access-Control-Allow-Headers': 'Content-Type',
     };
 
@@ -54,81 +67,41 @@ export default {
     // Route API requests to the appropriate handler
     if (path === '/api/weather') {
       const response = await weatherRequest({ request, env, ctx });
-      // Add CORS headers to the response
-      const newHeaders = new Headers(response.headers);
-      Object.keys(corsHeaders).forEach(key => {
-        newHeaders.set(key, corsHeaders[key]);
-      });
-      return new Response(response.body, {
-        status: response.status,
-        statusText: response.statusText,
-        headers: newHeaders,
-      });
+      return addCorsHeaders(response, corsHeaders);
     }
 
     if (path === '/api/forex') {
       const response = await forexRequest({ request, env, ctx });
-      // Add CORS headers to the response
-      const newHeaders = new Headers(response.headers);
-      Object.keys(corsHeaders).forEach(key => {
-        newHeaders.set(key, corsHeaders[key]);
-      });
-      return new Response(response.body, {
-        status: response.status,
-        statusText: response.statusText,
-        headers: newHeaders,
-      });
+      return addCorsHeaders(response, corsHeaders);
     }
 
     // Handle the new KV-only endpoints
     if (path === '/weather') {
       const response = await weatherKVRequest({ request, env, ctx });
-      // Add CORS headers to the response
-      const newHeaders = new Headers(response.headers);
-      Object.keys(corsHeaders).forEach(key => {
-        newHeaders.set(key, corsHeaders[key]);
-      });
-      return new Response(response.body, {
-        status: response.status,
-        statusText: response.statusText,
-        headers: newHeaders,
-      });
+      return addCorsHeaders(response, corsHeaders);
     }
 
     if (path === '/forex') {
       const response = await forexKVRequest({ request, env, ctx });
-      // Add CORS headers to the response
-      const newHeaders = new Headers(response.headers);
-      Object.keys(corsHeaders).forEach(key => {
-        newHeaders.set(key, corsHeaders[key]);
-      });
-      return new Response(response.body, {
-        status: response.status,
-        statusText: response.statusText,
-        headers: newHeaders,
-      });
+      return addCorsHeaders(response, corsHeaders);
     }
 
     if (path === '/api/crawl') {
       const response = await crawlRequest({ request, env, ctx });
-      // Add CORS headers to the response
-      const newHeaders = new Headers(response.headers);
-      Object.keys(corsHeaders).forEach(key => {
-        newHeaders.set(key, corsHeaders[key]);
-      });
-      return new Response(response.body, {
-        status: response.status,
-        statusText: response.statusText,
-        headers: newHeaders,
-      });
+      return addCorsHeaders(response, corsHeaders);
+    }
+
+    if (path === '/api/report-hotline') {
+      const response = await reportHotlineRequest({ request, env, ctx });
+      return addCorsHeaders(response, corsHeaders);
     }
 
     // Simple API to check if the functions are running
     if (path === '/api/status') {
-      return new Response(
+      const response = new Response(
         JSON.stringify({
           status: 'online',
-          functions: ['weather', 'forex', 'crawl'],
+          functions: ['weather', 'forex', 'crawl', 'report-hotline'],
           endpoints: [
             {
               path: '/api/weather',
@@ -205,20 +178,53 @@ export default {
                 },
               ],
             },
+            {
+              path: '/api/report-hotline',
+              description:
+                'Submit a report about outdated hotline information (creates GitHub issue)',
+              method: 'POST',
+              parameters: [
+                {
+                  name: 'hotlineName',
+                  required: true,
+                  description: 'Name of the hotline with outdated information',
+                },
+                {
+                  name: 'issue',
+                  required: true,
+                  description: 'Description of what is incorrect',
+                },
+                {
+                  name: 'correctInfo',
+                  required: false,
+                  description: 'The correct information if known',
+                },
+                {
+                  name: 'source',
+                  required: false,
+                  description: 'Link to official source',
+                },
+                {
+                  name: 'reporterEmail',
+                  required: false,
+                  description: 'Contact email of the reporter',
+                },
+              ],
+            },
           ],
           timestamp: new Date().toISOString(),
         }),
         {
           headers: {
             'Content-Type': 'application/json',
-            ...corsHeaders,
           },
         }
       );
+      return addCorsHeaders(response, corsHeaders);
     }
 
     // Return 404 for any other routes
-    return new Response(
+    const response = new Response(
       JSON.stringify({
         error: 'Not found',
         availableEndpoints: [
@@ -226,6 +232,7 @@ export default {
           '/api/weather',
           '/api/forex',
           '/api/crawl',
+          '/api/report-hotline',
           '/weather',
           '/forex',
         ],
@@ -234,9 +241,9 @@ export default {
         status: 404,
         headers: {
           'Content-Type': 'application/json',
-          ...corsHeaders,
         },
       }
     );
+    return addCorsHeaders(response, corsHeaders);
   },
 };

--- a/functions/types.ts
+++ b/functions/types.ts
@@ -16,6 +16,8 @@ export interface Env {
   JINA_API_KEY?: string;
   CF_ACCOUNT_ID?: string;
   CF_API_TOKEN?: string;
+  GITHUB_TOKEN?: string;
+  NODE_ENV?: string;
 }
 
 export interface WeatherData {

--- a/src/components/ReportHotlineModal.tsx
+++ b/src/components/ReportHotlineModal.tsx
@@ -1,5 +1,5 @@
 import { FC, useState, useEffect, useRef } from 'react';
-import { AlertCircleIcon, XIcon, ExternalLinkIcon } from 'lucide-react';
+import { AlertCircleIcon, XIcon } from 'lucide-react';
 
 interface ReportHotlineModalProps {
   isOpen: boolean;
@@ -161,8 +161,7 @@ const ReportHotlineModal: FC<ReportHotlineModalProps> = ({
       if (response.ok) {
         setSubmitStatus({
           type: 'success',
-          message: 'Report submitted successfully!',
-          issueUrl: data.issueUrl,
+          message: 'Report submitted successfully! We will review it soon.',
         });
         // Reset form
         setFormData({
@@ -191,13 +190,13 @@ const ReportHotlineModal: FC<ReportHotlineModalProps> = ({
         setSubmitStatus({
           type: 'error',
           message:
-            'Request timed out. Please check your connection and try again, or report directly on GitHub.',
+            'Request timed out. Please check your connection and try again.',
         });
       } else {
         setSubmitStatus({
           type: 'error',
           message:
-            'Network error. Please try again or report directly on GitHub.',
+            'Network error. Please try again or contact us at bugs@bettergov.ph',
         });
       }
     } finally {
@@ -206,27 +205,6 @@ const ReportHotlineModal: FC<ReportHotlineModalProps> = ({
         setIsSubmitting(false);
       }
     }
-  };
-
-  const openGitHubIssue = () => {
-    const issueTitle = encodeURIComponent('Outdated Hotline Information');
-    const issueBody = encodeURIComponent(
-      `## Hotline Information Issue\n\n` +
-        `### Which hotline has outdated information?\n` +
-        `${formData.hotlineName || '<!-- Please specify the hotline name -->'}\n\n` +
-        `### What is incorrect?\n` +
-        `${formData.issue || '<!-- Describe what information is outdated or incorrect -->'}\n\n` +
-        `### What should it be?\n` +
-        `${formData.correctInfo || '<!-- Provide the correct information if you know it -->'}\n\n` +
-        `### Source (optional)\n` +
-        `${formData.source || '<!-- Link to official source confirming the correct information -->'}\n\n` +
-        `---\n` +
-        `Reported from: /philippines/hotlines`
-    );
-    window.open(
-      `https://github.com/bettergovph/bettergov/issues/new?title=${issueTitle}&body=${issueBody}&labels=hotline,data-update`,
-      '_blank'
-    );
   };
 
   return (
@@ -275,17 +253,6 @@ const ReportHotlineModal: FC<ReportHotlineModalProps> = ({
               </div>
               <h3 className='text-xl font-semibold mb-2'>Thank you!</h3>
               <p className='text-gray-600 mb-4'>{submitStatus.message}</p>
-              {submitStatus.issueUrl && (
-                <a
-                  href={submitStatus.issueUrl}
-                  target='_blank'
-                  rel='noopener noreferrer'
-                  className='inline-flex items-center text-blue-600 hover:underline'
-                >
-                  View your report on GitHub
-                  <ExternalLinkIcon className='h-4 w-4 ml-1' />
-                </a>
-              )}
               <div className='mt-6'>
                 <button
                   onClick={onClose}
@@ -299,7 +266,7 @@ const ReportHotlineModal: FC<ReportHotlineModalProps> = ({
             <>
               <p className='text-gray-600 mb-6'>
                 Help us keep hotline information accurate and up-to-date. Your
-                report will be submitted as a GitHub issue.
+                report will be reviewed by our team.
               </p>
 
               {submitStatus.type === 'error' && (
@@ -416,24 +383,16 @@ const ReportHotlineModal: FC<ReportHotlineModalProps> = ({
                   <button
                     type='submit'
                     disabled={isSubmitting}
-                    className='flex-1 px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors disabled:bg-gray-400 disabled:cursor-not-allowed'
+                    className='w-full px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors disabled:bg-gray-400 disabled:cursor-not-allowed'
                   >
                     {isSubmitting ? 'Submitting...' : 'Submit Report'}
-                  </button>
-                  <button
-                    type='button'
-                    onClick={openGitHubIssue}
-                    className='flex-1 px-6 py-3 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition-colors flex items-center justify-center'
-                  >
-                    <ExternalLinkIcon className='h-4 w-4 mr-2' />
-                    Open in GitHub
                   </button>
                 </div>
               </form>
 
               <p className='text-xs text-gray-500 mt-4 text-center'>
-                Don&apos;t have a GitHub account? No problem! Use the form above
-                to submit your report.
+                Your report will be sent to our team for review. If you provided
+                an email, we may contact you for clarification.
               </p>
             </>
           )}

--- a/src/components/ReportHotlineModal.tsx
+++ b/src/components/ReportHotlineModal.tsx
@@ -1,5 +1,5 @@
 import { FC, useState, useEffect, useRef } from 'react';
-import { AlertCircleIcon, XIcon } from 'lucide-react';
+import { AlertCircleIcon, XIcon, ExternalLinkIcon } from 'lucide-react';
 
 interface ReportHotlineModalProps {
   isOpen: boolean;
@@ -161,7 +161,8 @@ const ReportHotlineModal: FC<ReportHotlineModalProps> = ({
       if (response.ok) {
         setSubmitStatus({
           type: 'success',
-          message: 'Report submitted successfully! We will review it soon.',
+          message: 'Report submitted successfully!',
+          issueUrl: data.issueUrl,
         });
         // Reset form
         setFormData({
@@ -253,6 +254,17 @@ const ReportHotlineModal: FC<ReportHotlineModalProps> = ({
               </div>
               <h3 className='text-xl font-semibold mb-2'>Thank you!</h3>
               <p className='text-gray-600 mb-4'>{submitStatus.message}</p>
+              {submitStatus.issueUrl && (
+                <a
+                  href={submitStatus.issueUrl}
+                  target='_blank'
+                  rel='noopener noreferrer'
+                  className='inline-flex items-center text-blue-600 hover:underline mb-4'
+                >
+                  View your report on GitHub
+                  <ExternalLinkIcon className='h-4 w-4 ml-1' />
+                </a>
+              )}
               <div className='mt-6'>
                 <button
                   onClick={onClose}
@@ -266,7 +278,8 @@ const ReportHotlineModal: FC<ReportHotlineModalProps> = ({
             <>
               <p className='text-gray-600 mb-6'>
                 Help us keep hotline information accurate and up-to-date. Your
-                report will be reviewed by our team.
+                report will be submitted as a public GitHub issue so volunteers
+                can help fix it.
               </p>
 
               {submitStatus.type === 'error' && (
@@ -370,9 +383,9 @@ const ReportHotlineModal: FC<ReportHotlineModalProps> = ({
                         className='mt-1 mr-2 h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded'
                       />
                       <span className='text-xs text-gray-600'>
-                        I consent to sharing my email address. It will be stored
-                        securely in server logs (not in the public GitHub issue)
-                        so maintainers can contact me for clarification if
+                        I consent to sharing my email address. It will be
+                        visible only to maintainers (not in the public GitHub
+                        issue) so they can contact me for clarification if
                         needed.
                       </span>
                     </label>
@@ -391,8 +404,9 @@ const ReportHotlineModal: FC<ReportHotlineModalProps> = ({
               </form>
 
               <p className='text-xs text-gray-500 mt-4 text-center'>
-                Your report will be sent to our team for review. If you provided
-                an email, we may contact you for clarification.
+                Your report will be publicly visible on GitHub. Your email (if
+                provided) will only be visible to maintainers in a private
+                comment.
               </p>
             </>
           )}

--- a/src/components/ReportHotlineModal.tsx
+++ b/src/components/ReportHotlineModal.tsx
@@ -29,6 +29,15 @@ const ReportHotlineModal: FC<ReportHotlineModalProps> = ({
 
   const modalRef = useRef<HTMLDivElement>(null);
   const previouslyFocusedElement = useRef<HTMLElement | null>(null);
+  const isMountedRef = useRef(true);
+
+  // Track mounted state
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
 
   // Escape key handler
   useEffect(() => {
@@ -141,10 +150,13 @@ const ReportHotlineModal: FC<ReportHotlineModalProps> = ({
         signal: controller.signal,
       });
 
-      // Clear timeout on successful fetch
+      const data = await response.json();
+
+      // Clear timeout after both fetch and JSON parse complete
       clearTimeout(timeoutId);
 
-      const data = await response.json();
+      // Only update state if component is still mounted
+      if (!isMountedRef.current) return;
 
       if (response.ok) {
         setSubmitStatus({
@@ -171,6 +183,9 @@ const ReportHotlineModal: FC<ReportHotlineModalProps> = ({
       // Clear timeout in case of error
       clearTimeout(timeoutId);
 
+      // Only update state if component is still mounted
+      if (!isMountedRef.current) return;
+
       // Check if the error was due to abort (timeout)
       if (error instanceof Error && error.name === 'AbortError') {
         setSubmitStatus({
@@ -186,7 +201,10 @@ const ReportHotlineModal: FC<ReportHotlineModalProps> = ({
         });
       }
     } finally {
-      setIsSubmitting(false);
+      // Only update state if component is still mounted
+      if (isMountedRef.current) {
+        setIsSubmitting(false);
+      }
     }
   };
 

--- a/src/components/ReportHotlineModal.tsx
+++ b/src/components/ReportHotlineModal.tsx
@@ -1,0 +1,428 @@
+import { FC, useState, useEffect, useRef } from 'react';
+import { AlertCircleIcon, XIcon, ExternalLinkIcon } from 'lucide-react';
+
+interface ReportHotlineModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  closeOnBackdropClick?: boolean;
+}
+
+const ReportHotlineModal: FC<ReportHotlineModalProps> = ({
+  isOpen,
+  onClose,
+  closeOnBackdropClick = true,
+}) => {
+  const [formData, setFormData] = useState({
+    hotlineName: '',
+    issue: '',
+    correctInfo: '',
+    source: '',
+    reporterEmail: '',
+  });
+  const [emailConsent, setEmailConsent] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitStatus, setSubmitStatus] = useState<{
+    type: 'success' | 'error' | null;
+    message: string;
+    issueUrl?: string;
+  }>({ type: null, message: '' });
+
+  const modalRef = useRef<HTMLDivElement>(null);
+  const previouslyFocusedElement = useRef<HTMLElement | null>(null);
+
+  // Escape key handler
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen, onClose]);
+
+  // Focus management: capture previous focus and set initial focus
+  useEffect(() => {
+    if (!isOpen) return;
+
+    // Capture the currently focused element
+    previouslyFocusedElement.current = document.activeElement as HTMLElement;
+
+    // Set focus to the first focusable element in the modal
+    const focusableElements = modalRef.current?.querySelectorAll<HTMLElement>(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    );
+
+    if (focusableElements && focusableElements.length > 0) {
+      focusableElements[0].focus();
+    }
+
+    // Restore focus when modal closes
+    return () => {
+      if (previouslyFocusedElement.current) {
+        previouslyFocusedElement.current.focus();
+      }
+    };
+  }, [isOpen]);
+
+  // Focus trap: keep focus within modal
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleTabKey = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab') return;
+
+      const focusableElements = modalRef.current?.querySelectorAll<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      );
+
+      if (!focusableElements || focusableElements.length === 0) return;
+
+      const firstElement = focusableElements[0];
+      const lastElement = focusableElements[focusableElements.length - 1];
+
+      if (e.shiftKey) {
+        // Shift + Tab: moving backwards
+        if (document.activeElement === firstElement) {
+          e.preventDefault();
+          lastElement.focus();
+        }
+      } else {
+        // Tab: moving forwards
+        if (document.activeElement === lastElement) {
+          e.preventDefault();
+          firstElement.focus();
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleTabKey);
+    return () => {
+      document.removeEventListener('keydown', handleTabKey);
+    };
+  }, [isOpen]);
+
+  // Backdrop click handler
+  const handleBackdropClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (closeOnBackdropClick && e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
+  if (!isOpen) return null;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsSubmitting(true);
+    setSubmitStatus({ type: null, message: '' });
+
+    // Create AbortController for timeout handling
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => {
+      controller.abort();
+    }, 10000); // 10 second timeout
+
+    try {
+      const response = await fetch('/api/report-hotline', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          ...formData,
+          // Only include email if consent is given
+          reporterEmail: emailConsent ? formData.reporterEmail : '',
+        }),
+        signal: controller.signal,
+      });
+
+      // Clear timeout on successful fetch
+      clearTimeout(timeoutId);
+
+      const data = await response.json();
+
+      if (response.ok) {
+        setSubmitStatus({
+          type: 'success',
+          message: 'Report submitted successfully!',
+          issueUrl: data.issueUrl,
+        });
+        // Reset form
+        setFormData({
+          hotlineName: '',
+          issue: '',
+          correctInfo: '',
+          source: '',
+          reporterEmail: '',
+        });
+        setEmailConsent(false);
+      } else {
+        setSubmitStatus({
+          type: 'error',
+          message: data.error || 'Failed to submit report',
+        });
+      }
+    } catch (error) {
+      // Clear timeout in case of error
+      clearTimeout(timeoutId);
+
+      // Check if the error was due to abort (timeout)
+      if (error instanceof Error && error.name === 'AbortError') {
+        setSubmitStatus({
+          type: 'error',
+          message:
+            'Request timed out. Please check your connection and try again, or report directly on GitHub.',
+        });
+      } else {
+        setSubmitStatus({
+          type: 'error',
+          message:
+            'Network error. Please try again or report directly on GitHub.',
+        });
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const openGitHubIssue = () => {
+    const issueTitle = encodeURIComponent('Outdated Hotline Information');
+    const issueBody = encodeURIComponent(
+      `## Hotline Information Issue\n\n` +
+        `### Which hotline has outdated information?\n` +
+        `${formData.hotlineName || '<!-- Please specify the hotline name -->'}\n\n` +
+        `### What is incorrect?\n` +
+        `${formData.issue || '<!-- Describe what information is outdated or incorrect -->'}\n\n` +
+        `### What should it be?\n` +
+        `${formData.correctInfo || '<!-- Provide the correct information if you know it -->'}\n\n` +
+        `### Source (optional)\n` +
+        `${formData.source || '<!-- Link to official source confirming the correct information -->'}\n\n` +
+        `---\n` +
+        `Reported from: /philippines/hotlines`
+    );
+    window.open(
+      `https://github.com/bettergovph/bettergov/issues/new?title=${issueTitle}&body=${issueBody}&labels=hotline,data-update`,
+      '_blank'
+    );
+  };
+
+  return (
+    <div
+      className='fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4'
+      onClick={handleBackdropClick}
+      role='dialog'
+      aria-modal='true'
+      aria-labelledby='modal-title'
+    >
+      <div
+        ref={modalRef}
+        className='bg-white rounded-lg shadow-xl max-w-2xl w-full max-h-[90vh] overflow-y-auto'
+        onClick={e => e.stopPropagation()}
+      >
+        <div className='sticky top-0 bg-white border-b border-gray-200 px-6 py-4 flex justify-between items-center'>
+          <h2 id='modal-title' className='text-2xl font-bold'>
+            Report Outdated Hotline
+          </h2>
+          <button
+            onClick={onClose}
+            className='text-gray-400 hover:text-gray-600 transition-colors'
+            aria-label='Close'
+          >
+            <XIcon className='h-6 w-6' />
+          </button>
+        </div>
+
+        <div className='p-6'>
+          {submitStatus.type === 'success' ? (
+            <div className='text-center py-8'>
+              <div className='mb-4 text-green-600'>
+                <svg
+                  className='w-16 h-16 mx-auto'
+                  fill='none'
+                  stroke='currentColor'
+                  viewBox='0 0 24 24'
+                >
+                  <path
+                    strokeLinecap='round'
+                    strokeLinejoin='round'
+                    strokeWidth={2}
+                    d='M5 13l4 4L19 7'
+                  />
+                </svg>
+              </div>
+              <h3 className='text-xl font-semibold mb-2'>Thank you!</h3>
+              <p className='text-gray-600 mb-4'>{submitStatus.message}</p>
+              {submitStatus.issueUrl && (
+                <a
+                  href={submitStatus.issueUrl}
+                  target='_blank'
+                  rel='noopener noreferrer'
+                  className='inline-flex items-center text-blue-600 hover:underline'
+                >
+                  View your report on GitHub
+                  <ExternalLinkIcon className='h-4 w-4 ml-1' />
+                </a>
+              )}
+              <div className='mt-6'>
+                <button
+                  onClick={onClose}
+                  className='px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors'
+                >
+                  Close
+                </button>
+              </div>
+            </div>
+          ) : (
+            <>
+              <p className='text-gray-600 mb-6'>
+                Help us keep hotline information accurate and up-to-date. Your
+                report will be submitted as a GitHub issue.
+              </p>
+
+              {submitStatus.type === 'error' && (
+                <div className='mb-4 p-4 bg-red-50 border border-red-200 rounded-lg text-red-700'>
+                  <AlertCircleIcon className='h-5 w-5 inline mr-2' />
+                  {submitStatus.message}
+                </div>
+              )}
+
+              <form onSubmit={handleSubmit} className='space-y-4'>
+                <div>
+                  <label className='block text-sm font-medium text-gray-700 mb-1'>
+                    Hotline Name <span className='text-red-500'>*</span>
+                  </label>
+                  <input
+                    type='text'
+                    required
+                    value={formData.hotlineName}
+                    onChange={e =>
+                      setFormData({ ...formData, hotlineName: e.target.value })
+                    }
+                    className='w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500'
+                    placeholder='e.g., National Emergency Hotline'
+                  />
+                </div>
+
+                <div>
+                  <label className='block text-sm font-medium text-gray-700 mb-1'>
+                    What is incorrect? <span className='text-red-500'>*</span>
+                  </label>
+                  <textarea
+                    required
+                    value={formData.issue}
+                    onChange={e =>
+                      setFormData({ ...formData, issue: e.target.value })
+                    }
+                    rows={3}
+                    className='w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500'
+                    placeholder='Describe what information is outdated or incorrect'
+                  />
+                </div>
+
+                <div>
+                  <label className='block text-sm font-medium text-gray-700 mb-1'>
+                    What should it be? (optional)
+                  </label>
+                  <textarea
+                    value={formData.correctInfo}
+                    onChange={e =>
+                      setFormData({ ...formData, correctInfo: e.target.value })
+                    }
+                    rows={3}
+                    className='w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500'
+                    placeholder='Provide the correct information if you know it'
+                  />
+                </div>
+
+                <div>
+                  <label className='block text-sm font-medium text-gray-700 mb-1'>
+                    Source (optional)
+                  </label>
+                  <input
+                    type='url'
+                    value={formData.source}
+                    onChange={e =>
+                      setFormData({ ...formData, source: e.target.value })
+                    }
+                    className='w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500'
+                    placeholder='Link to official source confirming the correct information'
+                  />
+                </div>
+
+                <div>
+                  <label className='block text-sm font-medium text-gray-700 mb-1'>
+                    Your Email (optional)
+                  </label>
+                  <input
+                    type='email'
+                    value={formData.reporterEmail}
+                    onChange={e =>
+                      setFormData({
+                        ...formData,
+                        reporterEmail: e.target.value,
+                      })
+                    }
+                    className='w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500'
+                    placeholder='your.email@example.com'
+                    disabled={!emailConsent}
+                  />
+                  <div className='mt-2'>
+                    <label className='flex items-start'>
+                      <input
+                        type='checkbox'
+                        checked={emailConsent}
+                        onChange={e => {
+                          setEmailConsent(e.target.checked);
+                          if (!e.target.checked) {
+                            setFormData({ ...formData, reporterEmail: '' });
+                          }
+                        }}
+                        className='mt-1 mr-2 h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded'
+                      />
+                      <span className='text-xs text-gray-600'>
+                        I consent to sharing my email address. It will be stored
+                        securely in server logs (not in the public GitHub issue)
+                        so maintainers can contact me for clarification if
+                        needed.
+                      </span>
+                    </label>
+                  </div>
+                </div>
+
+                <div className='flex gap-3 pt-4'>
+                  <button
+                    type='submit'
+                    disabled={isSubmitting}
+                    className='flex-1 px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors disabled:bg-gray-400 disabled:cursor-not-allowed'
+                  >
+                    {isSubmitting ? 'Submitting...' : 'Submit Report'}
+                  </button>
+                  <button
+                    type='button'
+                    onClick={openGitHubIssue}
+                    className='flex-1 px-6 py-3 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition-colors flex items-center justify-center'
+                  >
+                    <ExternalLinkIcon className='h-4 w-4 mr-2' />
+                    Open in GitHub
+                  </button>
+                </div>
+              </form>
+
+              <p className='text-xs text-gray-500 mt-4 text-center'>
+                Don&apos;t have a GitHub account? No problem! Use the form above
+                to submit your report.
+              </p>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ReportHotlineModal;

--- a/src/pages/philippines/Hotlines.tsx
+++ b/src/pages/philippines/Hotlines.tsx
@@ -1,5 +1,6 @@
 import { FC, useState } from 'react';
 import hotlinesData from '../../data/philippines_hotlines.json';
+import ReportHotlineModal from '../../components/ReportHotlineModal';
 
 interface Hotline {
   name: string;
@@ -22,6 +23,7 @@ import {
 const Hotlines: FC = () => {
   const [searchTerm, setSearchTerm] = useState('');
   const [activeCategory, setActiveCategory] = useState<string>('all');
+  const [isReportModalOpen, setIsReportModalOpen] = useState(false);
 
   const categories = [
     {
@@ -189,11 +191,23 @@ const Hotlines: FC = () => {
       </div>
 
       <div className='mt-12 text-center'>
-        <p className='text-sm text-gray-800'>
+        <p className='text-sm text-gray-800 mb-4'>
           These hotlines are collected from official government sources. If you
           notice any outdated information, please report it.
         </p>
+        <button
+          onClick={() => setIsReportModalOpen(true)}
+          className='inline-flex items-center px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors shadow-md'
+        >
+          <AlertCircleIcon className='h-5 w-5 mr-2' />
+          Report Outdated Information
+        </button>
       </div>
+
+      <ReportHotlineModal
+        isOpen={isReportModalOpen}
+        onClose={() => setIsReportModalOpen(false)}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Add Hotline Reporting Feature

Adds a reporting system for users to submit outdated hotline information directly from the Hotlines page. Reports are automatically created as GitHub issues.

### What's New
- Report modal with form validation and accessibility features
- `/api/report-hotline` endpoint that creates GitHub issues via API
- "Report Outdated Information" button on Hotlines page
- Privacy-first: optional email stored in server logs only, not in public issues

### Screenshots
<img width="1912" height="530" alt="image" src="https://github.com/user-attachments/assets/7dcb9fcf-f41c-4170-b72f-9df138e5558c" />

<img width="654" height="822" alt="image" src="https://github.com/user-attachments/assets/66c2647e-aaf8-490e-8d51-988f22a21f83" />



### Setup Required
Add `GITHUB_TOKEN` environment variable with `repo` scope to enable issue creation.
