### PR TITLE
fix(maps): adjust search bar z-index to prevent overlap with navbar items

### DIFF
--- a/src/pages/philippines/map/index.tsx
+++ b/src/pages/philippines/map/index.tsx
@@ -251,7 +251,7 @@ const PhilippinesMap: FC = () => {
       {/* Map Section */}
       <div className='flex-1 relative'>
         {/* Search Bar */}
-        <div className='absolute top-4 left-4 right-4 z-1000 max-w-md'>
+        <div className='absolute top-4 left-4 right-4 z-[5] max-w-md'>
           <div className='relative'>
             <SearchIcon className='absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 h-5 w-5' />
             <input


### PR DESCRIPTION
### Description
This pull request fixes the issue where the search bar in the Maps page overlaps the navigation items when hovering over them. The adjustment ensures that navigation elements correctly appear above the search bar.

### Changes Made
- Updated the z-index of the search bar container from z-[1000] to z-[5] to resolve the overlapping issue.

### Before
<img width="825" height="531" alt="image" src="https://github.com/user-attachments/assets/0809b0f9-24f0-4bd4-8ea0-e5732be173dc" />

### After
<img width="825" height="531" alt="image" src="https://github.com/user-attachments/assets/8f599452-1ef6-43b1-8792-648de26ed230" />
