### PR TITLE
fix: use cursor pointer on hover for services and flood control page

### DIFF
--- a/src/pages/services/index.tsx
+++ b/src/pages/services/index.tsx
@@ -364,7 +364,7 @@ export default function ServicesPage() {
                         className={`w-full text-left px-3 py-2 rounded-md text-sm transition-colors ${
                           selectedCategorySlug === 'all'
                             ? 'bg-primary-50 text-primary-600 font-medium'
-                            : 'text-gray-800 hover:bg-gray-50'
+                            : 'cursor-default text-gray-800 hover:bg-gray-50 hover:cursor-pointer'
                         }`}
                         aria-current={
                           selectedCategorySlug === 'all' ? 'true' : undefined
@@ -388,7 +388,7 @@ export default function ServicesPage() {
                             className={`w-full text-left px-3 py-2 rounded-md text-sm transition-colors ${
                               selectedCategorySlug === category.slug
                                 ? 'bg-primary-50 text-primary-600 font-medium'
-                                : 'text-gray-800 hover:bg-gray-50'
+                                : 'cursor-default text-gray-800 hover:bg-gray-50 hover:cursor-pointer'
                             }`}
                             aria-expanded={
                               selectedCategorySlug === category.slug
@@ -427,7 +427,7 @@ export default function ServicesPage() {
                                 className={`w-full text-left px-3 py-1.5 rounded-md text-sm transition-colors ${
                                   selectedSubcategorySlug === subcategory.slug
                                     ? 'bg-primary-50 text-primary-600 font-medium'
-                                    : 'text-gray-800 hover:bg-gray-50'
+                                    : 'cursor-default text-gray-800 hover:bg-gray-50 hover:cursor-pointer'
                                 }`}
                                 aria-current={
                                   selectedSubcategorySlug === subcategory.slug
@@ -485,7 +485,7 @@ export default function ServicesPage() {
                                 });
                                 setCurrentPage(1);
                               }}
-                              className='inline-block px-2 py-1 text-xs font-medium rounded-sm bg-primary-100 text-primary-800 hover:bg-primary-200 transition-colors'
+                              className='cursor-default inline-block px-2 py-1 text-xs font-medium rounded-sm bg-primary-100 text-primary-800 hover:bg-primary-200 transition-colors hover:cursor-pointer'
                             >
                               {service.category.name}
                             </button>
@@ -498,7 +498,7 @@ export default function ServicesPage() {
                                 });
                                 setCurrentPage(1);
                               }}
-                              className='inline-block px-2 py-1 text-xs font-medium rounded-sm bg-gray-100 text-gray-800 hover:bg-gray-200 transition-colors'
+                              className='cursor-default inline-block px-2 py-1 text-xs font-medium rounded-sm bg-gray-100 text-gray-800 hover:bg-gray-200 transition-colors hover:cursor-pointer'
                             >
                               {service.subcategory.name}
                             </button>
@@ -523,7 +523,7 @@ export default function ServicesPage() {
                           target='_blank'
                           rel='noopener noreferrer'
                         >
-                          <Button className='bg-blue-600 text-white rounded-lg px-4 py-1 text-xs mt-4'>
+                          <Button className='cursor-default bg-blue-600 text-white rounded-lg px-4 py-1 text-xs mt-4 hover:cursor-pointer'>
                             View Service
                           </Button>
                         </a>

--- a/src/pages/travel/visa/index.tsx
+++ b/src/pages/travel/visa/index.tsx
@@ -451,7 +451,7 @@ const VisaPage: FC = () => {
                 <span>{t('hero.dataSource')}</span>
               </div>
               <Link to='/travel/visa-types'>
-                <Button className='text-xl bg-blue-800 py-8 px-8 mt-6'>
+                <Button className='cursor-default text-xl bg-blue-800 py-8 px-8 mt-6 hover:cursor-pointer'>
                   {t('hero.checkVisaTypes')}
                 </Button>
               </Link>
@@ -467,7 +467,7 @@ const VisaPage: FC = () => {
                 </p>
                 <Button
                   onClick={handleCheckVisaRequirements}
-                  className='w-full bg-blue-600 hover:bg-blue-700 text-white'
+                  className='cursor-default w-full bg-blue-600 hover:bg-blue-700 text-white hover:cursor-pointer'
                 >
                   Check Visa Requirements
                 </Button>
@@ -685,7 +685,7 @@ const VisaPage: FC = () => {
           <DialogFooter>
             <Button
               onClick={closeDetailsDialog}
-              className='bg-blue-600 hover:bg-blue-700 text-white'
+              className='cursor-default bg-blue-600 hover:bg-blue-700 text-white hover:cursor-pointer'
             >
               Close
             </Button>


### PR DESCRIPTION
Previously, hovering over categories & buttons in services and flood control page does not change the cursor to a pointer (the one with the hand). This PR fixes that by using `cursor-default` and `hover:cursor-pointer` styles to buttons.