### PR TITLE
fix(SUCs): update Eulogio "Amang" Rodriguez Institute of Science and Technology website link

### DIFF
--- a/src/data/directory/constitutional.json
+++ b/src/data/directory/constitutional.json
@@ -2497,7 +2497,7 @@
     "name": "EULOGIO \"AMANG\" RODRIGUEZ INSTITUTE OF SCIENCE AND TECHNOLOGY",
     "address": "Nagtahan St., Sta. Mesa, Manila",
     "phone": "8230-2334 loc 101",
-    "website": "www.earist.edu.ph",
+    "website": "earist.edu.ph",
     "officials": [
       {
         "role": "President",


### PR DESCRIPTION
### Description
This pull request updates the website link of Eulogio "Amang" Rodriguez Institute of Science and Technology (EARIST) under the Constitutional Bodies → State Universities and Colleges (SUCs) section. The previous link included a redundant www prefix, which has been removed to ensure the link reflects the correct and accessible URL format.

### Changes Made
- Updated the website field value from www.earist.edu.ph to earist.edu.ph
- File modified: src/data/directory/constitutional.json

### Before
![1](https://github.com/user-attachments/assets/b03f2db8-0d8a-4f57-8a0a-a08c9f040b09)

### After
![2](https://github.com/user-attachments/assets/658a9692-9181-4125-ada8-abbb403c42db)