### PR TITLE
fix(SUCs): add Marikina Polytechnic College website link

### DIFF
--- a/src/data/directory/constitutional.json
+++ b/src/data/directory/constitutional.json
@@ -2513,6 +2513,7 @@
     "name": "MARIKINA POLYTECHNIC COLLEGE",
     "address": "Mayor Juan Chanyungco St., Sta Elena, Marikina City",
     "phone": "8682-0672 loc. 101, 102",
+    "website": "mpc.edu.ph",
     "officials": [
       {
         "role": "President",


### PR DESCRIPTION
### Description
Added the official website link for Marikina Polytechnic College to complete its directory information.

### Changes Made
- Updated src/data/directory/constitutional.json
- Added "website": "mpc.edu.ph" under Marikina Polytechnic College

### Before
<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/086b37e3-eda7-46a6-98e6-bf8c2a45cfb2" />

### After
<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/1797c975-cd65-47f3-afd0-61b1f26b8055" />