### PR TITLE
fix(SUCs): make "Visit website" button layout consistent across SUCs cards

### DIFF
--- a/src/pages/government/constitutional/sucs.tsx
+++ b/src/pages/government/constitutional/sucs.tsx
@@ -63,7 +63,7 @@ export default function SUCsPage() {
           filteredSUCs.map(suc => (
             <div
               key={suc.name}
-              className='bg-white rounded-lg border overflow-hidden'
+              className='bg-white rounded-lg border overflow-hidden flex flex-col h-full'
             >
               <div className='p-4 border-b'>
                 <h3 className='font-semibold text-lg text-gray-900 line-clamp-2'>
@@ -71,7 +71,7 @@ export default function SUCsPage() {
                 </h3>
               </div>
 
-              <div className='p-4 space-y-3'>
+              <div className='p-4 space-y-3 flex-1'>
                 {suc.address && (
                   <p className='text-sm text-gray-800 flex items-start'>
                     <MapPinIcon className='h-4 w-4 text-gray-400 mr-2 mt-0.5 flex-shrink-0' />
@@ -125,7 +125,7 @@ export default function SUCsPage() {
               </div>
 
               {suc.website && (
-                <div className='px-4 py-3 bg-gray-50 border-t'>
+                <div className='px-4 py-3 bg-gray-50 border-t mt-auto'>
                   <a
                     href={
                       suc.website.startsWith('http')


### PR DESCRIPTION
### Description
This pull request fixes the inconsistent placement of the "Visit website" button across the SUCs cards. Previously, the button’s position varied depending on the content height. The layout is now made consistent by ensuring the button stays anchored at the bottom of each card.

### Changes Made
- Added flex flex-col h-full to the card container.
- Applied flex-1 to the content area to allow flexible height.
- Added mt-auto to the "Visit website" container to keep it aligned at the bottom.
- Improved overall layout consistency for SUCs cards.

### Before
<img width="1504" height="829" alt="image" src="https://github.com/user-attachments/assets/d74a3e9e-d1e0-42c1-bc1f-7bfa86e505dc" />

### After
<img width="1504" height="829" alt="image" src="https://github.com/user-attachments/assets/33c7532f-6ac1-4362-8722-33b5ff816dd9" />