### PR TITLE
fix(SUCs): update University of the Philippines name and website link

### DIFF
--- a/src/data/directory/constitutional.json
+++ b/src/data/directory/constitutional.json
@@ -2605,10 +2605,10 @@
     "slug": "university-of-the-philippines-system",
     "office_type": "State Universities and Colleges (SUCs)",
     "region": "NATIONAL CAPITAL REGION",
-    "name": "UNIVERSITY OF THE PHILIPPINES SYSTEM",
+    "name": "UNIVERSITY OF THE PHILIPPINES",
     "address": "Diliman, Quezon City",
     "phone": "8928-0110; 8928-2866",
-    "website": "www.up.edu.ph",
+    "website": "up.edu.ph",
     "officials": [
       {
         "role": "President",


### PR DESCRIPTION
### Description
This pull request updates the website link for the University of the Philippines in the constitutional directory.

### Changes Made
- Updated name from “UNIVERSITY OF THE PHILIPPINES SYSTEM” to “UNIVERSITY OF THE PHILIPPINES”.
- Corrected website link from “www.up.edu.ph” to “up.edu.ph”.
- Ensured alignment with the university’s official information.

### Before
![before](https://github.com/user-attachments/assets/87227c5e-a34d-4371-a825-aaa71adf2b34)

### After
![after](https://github.com/user-attachments/assets/21419ec0-b6ac-4d73-9aed-acc6750ad459)