### PR TITLE
fix(SUCs): update Mountain Province State Polytechnic College website link

### DIFF
--- a/src/data/directory/constitutional.json
+++ b/src/data/directory/constitutional.json
@@ -2712,7 +2712,7 @@
     "name": "MOUNTAIN PROVINCE STATE POLYTECHNIC COLLEGE",
     "address": "Bontoc, Mountain Province",
     "phone": "(074) 601-1134",
-    "website": "www.mpspc.edu.ph",
+    "website": "mpsu.edu.ph",
     "officials": [
       {
         "role": "President",


### PR DESCRIPTION
### Description
This pull request updates the website link for Mountain Province State Polytechnic College. The previously listed domain (www.mpspc.edu.ph) was discovered to be a fraudulent or scam website impersonating the official institution. The update ensures the directory points to the legitimate domain (mpsu.edu.ph).

### Changes Made
- Replaced www.mpspc.edu.ph with mpsu.edu.ph.
- Verified that the new domain is the official website of the school.

### Before
![1](https://github.com/user-attachments/assets/72a8d680-eb0c-412c-a709-c4917ccf6429)

### After
![2](https://github.com/user-attachments/assets/bdf70a9f-5ac3-4865-9bf4-198f25aadca4)