### PR TITLE
fix(SUCs): add official website link for South Cotabato State College

### DIFF
--- a/src/data/directory/constitutional.json
+++ b/src/data/directory/constitutional.json
@@ -4086,6 +4086,7 @@
     "name": "SOUTH COTABATO STATE COLLEGE",
     "address": "Surallah, South Cotabato",
     "phone": "(083) 238-5143",
+    "website": "scsc.edu.ph",
     "officials": [
       {
         "role": "President",


### PR DESCRIPTION
### Description
This pull request adds the official website link of South Cotabato State College to the constitutional directory.

### Changes Made
- Added scsc.edu.ph as the website of South Cotabato State College.
- Verified that the link points to the official site of the institution.

### Before
<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/736ecfa7-1ed0-4222-ae5f-2ca6b84d27bb" />

### After
<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/e2f2acd5-6c8a-4bd1-a238-5607d1d8ce2d" />
