### PR TITLE
fix(SUCs): add official website link for Adiong Memorial State College

### DIFF
--- a/src/data/directory/constitutional.json
+++ b/src/data/directory/constitutional.json
@@ -4209,6 +4209,7 @@
     "region": "BANGSAMORO AUTONOMOUS REGION IN MUSLIM MINDANAO",
     "name": "ADIONG MEMORIAL STATE COLLEGE",
     "address": "Ditsaan-Ramain, Lanao del Sur",
+    "website": "amsc-edu.net",
     "officials": [
       {
         "role": "President",


### PR DESCRIPTION
### Description
This pull request adds the official website link for Adiong Memorial State College to the constitutional directory.

### Changes Made
- Added amsc-edu.net as the official website of Adiong Memorial State College.

### Before
<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/a1f8242a-70c6-4e47-b989-b82cb3ef8ac2" />

### After
<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/e659ade8-9777-45f6-a85e-0b46da75d9c2" />