### PR TITLE
fix(home): make cursor pointer when hovering Register Now button

### DIFF
--- a/src/components/home/PromotionBanner.tsx
+++ b/src/components/home/PromotionBanner.tsx
@@ -21,7 +21,7 @@ const PromotionBanner: FC = () => {
           <div>
             <Link to='https://philsys.gov.ph/registration-process'>
               <Button
-                className='bg-white text-accent-600 hover:bg-gray-100 shadow-lg px-8 py-3 text-lg'
+                className='bg-white text-accent-600 hover:bg-gray-100 shadow-lg px-8 py-3 text-lg cursor-pointer'
                 size='lg'
               >
                 {t('promotion.registerNow')}


### PR DESCRIPTION
### Description
Added a cursor pointer effect when hovering over the "Register Now" button to indicate interactivity.

### Before
<img width="273" height="261" alt="image" src="https://github.com/user-attachments/assets/07b6c105-96ec-4958-985b-709e219099eb" />

### After
<img width="273" height="261" alt="image" src="https://github.com/user-attachments/assets/06a34000-f9f4-4fbf-966f-d416b5b1e8a5" />