### PR TITLE
style(layout): keep "View details" button fixed at the bottom of each department card

### DIFF
--- a/src/pages/government/departments/index.tsx
+++ b/src/pages/government/departments/index.tsx
@@ -238,7 +238,7 @@ export default function DepartmentsIndex() {
                 key={index}
                 className='block'
               >
-                <Card hover={true} className='h-full'>
+                <Card hover={true} className='h-full flex flex-col'>
                   <CardHeader>
                     <div className='flex items-start justify-between'>
                       <div>
@@ -256,8 +256,8 @@ export default function DepartmentsIndex() {
                       </div>
                     </div>
                   </CardHeader>
-                  <CardContent>
-                    <div className='space-y-2'>
+                  <CardContent className='flex flex-col h-full grow'>
+                    <div className='space-y-2 flex-1'>
                       {dept.address && (
                         <div className='flex items-start'>
                           <MapPinIcon className='h-4 w-4 text-gray-400 mr-2 mt-0.5 shrink-0' />


### PR DESCRIPTION
### Description
This PR fixes the inconsistent layout issue on the Executive Departments page where the View Details button was not aligned uniformly across all cards. The layout has been refactored to use a flex column structure, ensuring the View Details button consistently stays at the bottom of each card regardless of content length.

### Before
<img width="1538" height="893" alt="image" src="https://github.com/user-attachments/assets/4f18b406-18f6-4155-a33d-6b9abb76f9fe" />

### After
<img width="1538" height="856" alt="image" src="https://github.com/user-attachments/assets/d8bb61dc-3ea6-4f0a-acab-637ae1ab5717" />