### PR TITLE
fix(senate): add contact information of Senator Panfilo "Ping" M. Lacson

### DIFF
--- a/src/data/directory/legislative.json
+++ b/src/data/directory/legislative.json
@@ -15,7 +15,7 @@
       {
         "role": "Senate President Pro Tempore",
         "name": "PANFILO M. LACSON",
-        "contact": "__"
+        "contact": "local nos. 5790-5792 / 8617"
       },
       {
         "role": "Senate Majority Leader",


### PR DESCRIPTION
### Description
This PR adds the official contact information of Senate President Pro Tempore Panfilo M. Lacson to the Senate page.

### Before
<img width="500" height="500" alt="image" src="https://github.com/user-attachments/assets/abd48ec5-4f47-4f67-b04e-9c45680654c8" />

### After
<img width="500" height="500" alt="image" src="https://github.com/user-attachments/assets/95ec7c23-645b-4635-9549-5d033f0df55e" />

### Reference
1. https://legacy.senate.gov.ph/contact18thcongress.asp
<img width="500" height="500" alt="image" src="https://github.com/user-attachments/assets/0aecb12d-f132-4d57-9379-93e38007dcce" />
