### PR TITLE
hotfix: default metatags

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,23 @@
       href="https://fonts.googleapis.com/css2?family=Figtree:wght@400;500;600;700&display=swap"
       rel="stylesheet"
     />
+    <meta
+      property="og:title"
+      content="BetterGov.ph | Republic of the Philippines | Community Powered Government Portal"
+    />
+    <meta
+      property="og:description"
+      content="Community-powered portal of the Republic of the Philippines. Access government services, stay updated with the latest news, and find information about the Philippines."
+    />
+    <meta
+      property="og:image"
+      content="/logos/jpg/BetterGov_Vertical-White.jpg"
+    />
+    <meta property="og:image:type" content="image/jpeg" />
+    <meta property="og:image:width" content="768" />
+    <meta property="og:image:height" content="768" />
+    <meta property="og:url" content="https://bettergov.ph/" />
+    <meta property="og:type" content="website" />
   </head>
 
   <body>

--- a/src/components/SEO.tsx
+++ b/src/components/SEO.tsx
@@ -119,9 +119,9 @@ export default function SEO({
 
   // Default values
   const defaultTitle =
-    'BetterGov.ph | Republic of the Philippines | Community Powered Government Portal';
+    'BetterGov.ph Philippines | Community Powered Government Portal';
   const defaultDescription =
-    'Community-powered portal of the Republic of the Philippines. Access government services, stay updated with the latest news, and find information about the Philippines.';
+    'Community-powered portal of the Philippines. Access government services, stay updated with the latest news, and find information about the Philippines.';
 
   useEffect(() => {
     // Force a re-render of this component on route or query-string changes
@@ -188,9 +188,8 @@ export default function SEO({
       <meta name='geo.country' content='PH' />
       <meta name='geo.region' content='PH' />
       <meta name='DC.language' content='en' />
-      <meta name='DC.creator' content='Republic of the Philippines' />
-      <meta name='DC.publisher' content='Philippine Government' />
-      <meta name='DC.rights' content='© Republic of the Philippines' />
+      <meta name='DC.creator' content='BetterGov.ph' />
+      <meta name='DC.publisher' content='BetterGov.ph' />
 
       {/* Structured Data */}
       {jsonLd && (


### PR DESCRIPTION
Due to opengraph not being fetched let's have the defaults in index.html

(will self merge as our share image is currently broken when being shared on Facebook and other sites)

<img width="1075" height="902" alt="image" src="https://github.com/user-attachments/assets/aae74d92-7b4f-44b4-be2e-6089983706f4" />
