### PR TITLE
fix(visa): prevent modal from opening when clicking country in detail view

### DIFF
--- a/src/pages/travel/visa/index.tsx
+++ b/src/pages/travel/visa/index.tsx
@@ -361,8 +361,11 @@ const VisaPage: FC = () => {
       if (requirement) {
         setVisaRequirement(requirement);
         // Auto-open dialog when country parameter is present in URL
-        setDialogCountry(selectedCountry);
-        setDialogOpen(true);
+        // Only open dialog in Grid View, not in Detail View (list mode)
+        if (viewMode !== 'list') {
+          setDialogCountry(selectedCountry);
+          setDialogOpen(true);
+        }
       }
     }
   }, [selectedCountry, countryRequirements, viewMode]);


### PR DESCRIPTION
### Description
This PR ensures that the country modal only opens when in Grid View. It prevents the modal from appearing unnecessarily when the user is already viewing country details in List (Detail) View.

### Changes Made
- Added a condition to only trigger the modal in Grid View
- Prevented modal activation when clicking a country in Detail View

### Before
![before](https://github.com/user-attachments/assets/dfb73fd4-c157-4dce-a543-ccf6378f512c)

### After
![after](https://github.com/user-attachments/assets/d0ff557e-dc50-42b7-923c-a1c1e6795c02)