### PR TITLE
fix(data): add email and update website link for Bohol Island State University 

### DIFF
--- a/src/data/directory/constitutional.json
+++ b/src/data/directory/constitutional.json
@@ -3571,6 +3571,7 @@
     "name": "BOHOL ISLAND STATE UNIVERSITY",
     "address": "Tagbilaran City, Bohol",
     "website": "bisu.edu.ph",
+    "email": "op@bisu.edu.ph",
     "officials": [
       {
         "role": "President",

--- a/src/data/websites.json
+++ b/src/data/websites.json
@@ -352,7 +352,7 @@
   {
     "name": "BOHOL ISLAND STATE UNIVERSITY",
     "slug": "bohol-island-state-university",
-    "email": null,
+    "email": "op@bisu.edu.ph",
     "website": "bisu.edu.ph",
     "address": "Tagbilaran City, Bohol",
     "contact": null,


### PR DESCRIPTION
### Description
This PR updates the website link for Bohol Island State University (BISU). The previous link redirected to a suspicious or spam website, so it has been replaced with the official and verified domain to ensure users receive accurate information. Additionally, the university’s official contact email has been added for completeness.

### Before
![before](https://github.com/user-attachments/assets/8a0e3333-7924-45a4-8390-9d43757972b9)

### After
![after](https://github.com/user-attachments/assets/efbd27d8-65d7-45ab-adeb-395e15181902)

### Screenshot
<img width="518" height="479" alt="image" src="https://github.com/user-attachments/assets/5e865e67-3baf-4e19-bf31-ddb534f938d3" />

### Reference
https://bisu.edu.ph/
