### PR TITLE
fix(SUCs): rename Don Honorio Ventura State University to Pampanga State University

### DIFF
--- a/src/data/directory/constitutional.json
+++ b/src/data/directory/constitutional.json
@@ -2960,10 +2960,10 @@
     "email": "op@clsu.edu.ph"
   },
   {
-    "slug": "don-honorio-ventura-state-university",
+    "slug": "pampanga-state-university",
     "office_type": "State Universities and Colleges (SUCs)",
     "region": "REGION III - CENTRAL LUZON",
-    "name": "DON HONORIO VENTURA STATE UNIVERSITY",
+    "name": "PAMPANGA STATE UNIVERSITY",
     "address": "Cabambangan, Bacolor, Pampanga",
     "phone": "(045) 649-8050",
     "website": "www.dhvsu.edu.ph",
@@ -2972,7 +2972,8 @@
         "role": "President",
         "name": "ENRIQUE G. BAKING"
       }
-    ]
+    ],
+    "email": "info@pampangastateu.edu.ph"
   },
   {
     "slug": "nueva-ecija-university-of-science-and-technology",

--- a/src/data/websites.json
+++ b/src/data/websites.json
@@ -2960,12 +2960,12 @@
     "parent_department": "DEPARTMENT OF HEALTH"
   },
   {
-    "name": "DON HONORIO VENTURA STATE UNIVERSITY",
-    "slug": "don-honorio-ventura-state-university",
-    "email": null,
+    "name": "PAMPANGA STATE UNIVERSITY",
+    "slug": "pampanga-state-university",
+    "email": "info@pampangastateu.edu.ph",
     "website": "www.dhvsu.edu.ph",
     "address": "Cabambangan, Bacolor, Pampanga",
-    "contact": null,
+    "contact": "(045) 649 8050",
     "type": "constitutional",
     "parent_department": null
   },


### PR DESCRIPTION
### Description
This PR renames Don Honorio Ventura State University to Pampanga State University, following the law signed by President Ferdinand Marcos Jr. on April 21, 2025.

### Changes Made
- Renamed the university from Don Honorio Ventura State University to Pampanga State University
- Updated the slug, email, and contact information
- Modified corresponding entries in constitutional.json and websites.json

### Before
<img width="492" height="392" alt="image" src="https://github.com/user-attachments/assets/0737c589-20c3-40e3-8d09-3e250cb3e38c" />

### After
<img width="484" height="446" alt="image" src="https://github.com/user-attachments/assets/ffa239fc-2a74-4581-a67e-4fe1c141d2b8" />

### References:
1. https://www.sunstar.com.ph/pampanga/marcos-signs-law-renaming-dhvsu-to-pampanga-state-u
2. https://pampanganewsnow.com/pbbm-signs-law-renaming-dhvsu-to-pampanga-state-university/