### PR TITLE
fix(services): update broken links under Certificates and IDs

### DIFF
--- a/src/data/services/certificates-ids.json
+++ b/src/data/services/certificates-ids.json
@@ -289,7 +289,7 @@
   },
   {
     "service": "Get a Solo Parent ID",
-    "url": "https://psa.gov.ph/sites/default/files/attachments/aodao/article/Q%20%26%20A_Solo%20Parent%27s%20Welfare%20Act%20and%20Parental%20Leave.pdf",
+    "url": "https://psahelpline.ph/blogs/a-simple-guide-to-obtaining-a-solo-parent-id-from-the-dswd",
     "id": "942f1e2e-64c7-48da-b961-3a16494a020c",
     "slug": "get-a-solo-parent-id",
     "published": true,


### PR DESCRIPTION
### Description
This PR closes #188. It updates two services under Certificates and IDs:
- Replaces the discontinued UMID with the new MySSS Card, following the SSS announcement.
- Updates the Solo Parent ID link to the PSA Helpline blog, which provides a detailed step-by-step guide for obtaining the ID.

### Screenshot
<img width="500" height="500" alt="image" src="https://github.com/user-attachments/assets/bba9b828-561b-4ac7-bb57-5c302504b6cc" />

### References
https://www.sss.gov.ph/mysss-card/
https://psahelpline.ph/blogs/a-simple-guide-to-obtaining-a-solo-parent-id-from-the-dswd