### PR TITLE
style(InfoWidgets): add faint gray separators to finalize uniform widget layout

### DIFF
--- a/src/components/home/InfoWidgets.tsx
+++ b/src/components/home/InfoWidgets.tsx
@@ -129,7 +129,7 @@ const InfoWidgets: FC = () => {
                   ))}
                 </div>
               )}
-              <div className='flex space-between w-full items-center'>
+              <div className='mt-4 border-t border-gray-200 flex space-between w-full items-center'>
                 <p className='text-sm text-gray-700 mt-4 text-right'>
                   Weather data provided by{' '}
                   <a
@@ -222,7 +222,7 @@ const InfoWidgets: FC = () => {
                   </tbody>
                 </table>
               </div>
-              <div className='text-right mt-4'>
+              <div className='mt-4 pt-3 border-t border-gray-200 text-right'>
                 <a
                   href='/data/forex'
                   className='text-primary-600 text-sm hover:underline'


### PR DESCRIPTION
### Description
This pull request adds faint gray separators to the remaining sections of the InfoWidgets component on the home page. The goal is to create a more cohesive and uniform appearance across all widgets. The Critical Emergency Hotlines widget already used these separators, so this update extends the same visual treatment to the Weather Updates and Forex widgets for consistency.

### Before
<img width="1841" height="633" alt="image" src="https://github.com/user-attachments/assets/25608a09-f8f4-44b1-895e-0da620c258b9" />

### After
<img width="1841" height="633" alt="image" src="https://github.com/user-attachments/assets/f029b8cf-e9f0-4d23-84d7-59eea98bd610" />
