### PR TITLE
fix(services): update link in multiple entry under Employment service

### DIFF
--- a/src/data/services/employment.json
+++ b/src/data/services/employment.json
@@ -180,24 +180,6 @@
     "updatedAt": "2025-06-06T11:30:06.320Z"
   },
   {
-    "service": "Apply for CSC Authentication of Certificate of Eligibility",
-    "url": "http://csc.gov.ph/2014-02-27-07-38-08/2014-02-27-07-39-33.html",
-    "id": "e152ec2d-39cf-4548-80fe-fcf3e2ce9819",
-    "slug": "apply-for-csc-authentication-of-certificate-of-eligibility",
-    "published": true,
-    "featured": false,
-    "category": {
-      "name": "Employment",
-      "slug": "employment"
-    },
-    "subcategory": {
-      "name": "Professionals",
-      "slug": "professionals"
-    },
-    "createdAt": "2025-06-06T11:30:06.320Z",
-    "updatedAt": "2025-06-06T11:30:06.320Z"
-  },
-  {
     "service": "Apply for CSC Examination",
     "url": "https://csc.gov.ph/downloads/category/459-cse-application-form",
     "id": "c5165964-9e1e-45fc-87a9-7a29cec59734",
@@ -220,24 +202,6 @@
     "url": "https://csc.gov.ph/special-eligibilities",
     "id": "6c5a586d-c139-4e52-bdd4-e7d33b7bf4f7",
     "slug": "apply-for-csc-grant-of-eligibility-under-special-laws-and-csc-issuances",
-    "published": true,
-    "featured": false,
-    "category": {
-      "name": "Employment",
-      "slug": "employment"
-    },
-    "subcategory": {
-      "name": "Professionals",
-      "slug": "professionals"
-    },
-    "createdAt": "2025-06-06T11:30:06.320Z",
-    "updatedAt": "2025-06-06T11:30:06.320Z"
-  },
-  {
-    "service": "Claim CSC Certificate of Eligibility",
-    "url": "http://csc.gov.ph/2014-02-27-07-38-08/2014-02-27-07-39-33.html",
-    "id": "f8fa9688-6364-4ac2-98c8-5dec115265bf",
-    "slug": "claim-csc-certificate-of-eligibility",
     "published": true,
     "featured": false,
     "category": {


### PR DESCRIPTION
### Description
This pull request updates multiple entries in the Employment category under the Services page to ensure all information is accurate and up to date.

<details><summary>Merge PRC-related entries into one</summary>
The previous three PRC-related entries all pointed to the same website. They have been consolidated into a single entry for a cleaner and more consistent user experience.

### Screenshot
<img width="742" height="315" alt="image" src="https://github.com/user-attachments/assets/708583c5-defc-4e3b-82e8-168e726976c1" />

</details>

<details><summary>Update link for Registering Enterprised-based Union</summary>
The previous link led to a DOLE page that returned a 403 error. This update corrects the link to point to the proper website.

### Before
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/4ea81b4a-6dee-41db-909b-f591f201b948" />

### After
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/35afcf10-dfb1-42ea-9e6a-addf1bee48d8" />

</details>

<details><summary>Update CSC special eligibility link</summary>
The previous URL was outdated (from 2014). This update points to the current page for CSC special eligibilities.

### Screenshot
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/c7620818-f513-4246-abdb-2aa36bffc8ac" />

</details>

<details><summary>Update CSC examination application link</summary>
The link for applying to the CSC examination has been updated to the correct and current page.

### Screenshot
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/6611b30c-48a6-4811-b8e8-5027bca5dded" />

</details>

### References
https://verification.prc.gov.ph/
https://ours.dole.gov.ph/
https://csc.gov.ph/downloads/category/459-cse-application-form
https://csc.gov.ph/special-eligibilities