### PR TITLE
chore(ci): format wrangler.jsonc with prettier

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -10,7 +10,7 @@ const config = {
   '*.{js,jsx,ts,tsx,cjs,mjs}': [buildEslintCommand],
 
   // Prettier for various file types
-  '*.{js,jsx,ts,tsx,cjs,mjs,json,md,yml,yaml,css,scss,html}': [
+  '*.{js,jsx,ts,tsx,cjs,mjs,json,jsonc,md,yml,yaml,css,scss,html}': [
     'prettier --write',
   ],
 };

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,23 +1,23 @@
- {
-    "name": "bettergovph",
-    "account_id": "cd41784b73cc20f93b3137292f818ff6",
-    "compatibility_date": "2025-11-17",
-    "assets": {
-      "directory": "./dist",
-      "not_found_handling": "single-page-application"
+{
+  "name": "bettergovph",
+  "account_id": "cd41784b73cc20f93b3137292f818ff6",
+  "compatibility_date": "2025-11-17",
+  "assets": {
+    "directory": "./dist",
+    "not_found_handling": "single-page-application",
+  },
+  "kv_namespaces": [
+    {
+      "id": "124001eaebfb4815b32db5344fc59251",
+      "binding": "BROWSER_KV",
     },
-    "kv_namespaces": [
-      {
-        "id": "124001eaebfb4815b32db5344fc59251",
-        "binding": "BROWSER_KV"
-      },
-      {
-        "id": "a1151781bef24f3092aa3ddefe86aac5",
-        "binding": "FOREX_KV"
-      },
-      {
-        "id": "7e1c950bb42d4282b13e3e9524ce5335",
-        "binding": "WEATHER_KV"
-      }
-    ]
-  }
+    {
+      "id": "a1151781bef24f3092aa3ddefe86aac5",
+      "binding": "FOREX_KV",
+    },
+    {
+      "id": "7e1c950bb42d4282b13e3e9524ce5335",
+      "binding": "WEATHER_KV",
+    },
+  ],
+}


### PR DESCRIPTION
Apply prettier format rules to `wrangler.jsonc` and update `lint-staged` config so `jsonc` files are formatted during `pre-commit`.