### PR TITLE
fix(accessibility): correct inaccurate "last updated" date in accessibility statement

### DIFF
--- a/src/pages/accessibility/index.tsx
+++ b/src/pages/accessibility/index.tsx
@@ -390,7 +390,7 @@ const AccessibilityPage: FC = () => {
             <div className='p-6 md:p-8 text-center'>
               <p className='text-sm text-gray-800'>
                 This accessibility statement was last updated on{' '}
-                <time dateTime='2024-01-15'>January 15, 2024</time>.
+                <time dateTime='2025-09-08'>September 8, 2025</time>.
               </p>
               <p className='text-sm text-gray-800 mt-2'>
                 We review and update this statement regularly to ensure it


### PR DESCRIPTION
### Description
This pull request updates the “last updated” date in the Accessibility page.  The existing date (January 15, 2024) was incorrect.   Based on the project’s Git history, the statement was originally created on September 8, 2025 (commit 5725650).

### Before
<img width="763" height="162" alt="image" src="https://github.com/user-attachments/assets/186b5c95-43a6-4e38-a31e-822d69da713d" />

### After
<img width="763" height="162" alt="image" src="https://github.com/user-attachments/assets/2229399b-4c23-4e2c-b71d-8d14240dc204" />
