### PR TITLE
fix(services): update outdated URLs in Education services

### DIFF
--- a/src/data/services/education.json
+++ b/src/data/services/education.json
@@ -55,7 +55,7 @@
   },
   {
     "service": "Apply for CHED Foreign Scholarship and Training Programs",
-    "url": "https://ched.gov.ph/stufaps/",
+    "url": "https://ched.e.gov.ph/foreign-scholarship-training-program",
     "id": "fbba6f06-25e8-49c9-9e83-9de02c7e31b9",
     "slug": "apply-for-ched-foreign-scholarship-and-training-programs",
     "published": true,
@@ -73,7 +73,7 @@
   },
   {
     "service": "Register for a COA Training",
-    "url": "https://www.coa.gov.ph/nom/",
+    "url": "https://www.coa.gov.ph/trainings/",
     "id": "b917ad09-3c29-43c2-9648-da1b645d6b2d",
     "slug": "register-for-a-coa-training",
     "published": true,
@@ -91,7 +91,7 @@
   },
   {
     "service": "Apply for TESDA Online Program",
-    "url": "https://www.e-tesda.gov.ph/login/signup.php",
+    "url": "https://e-tesda.gov.ph/",
     "id": "4d14d5da-ac0b-4833-a4f3-2defaa63bc2d",
     "slug": "apply-for-tesda-online-program",
     "published": true,
@@ -127,7 +127,7 @@
   },
   {
     "service": "Apply for DA eLearning Certification",
-    "url": "http://e-extension.gov.ph/elearning/",
+    "url": "https://elearn.e-extension.gov.ph/login/signup.php",
     "id": "885b16fb-47f6-419b-8798-633d7808d1be",
     "slug": "apply-for-da-elearning-certification",
     "published": true,
@@ -145,7 +145,7 @@
   },
   {
     "service": "Apply for TESDA Scholarship",
-    "url": "https://www.tesda.gov.ph/Barangay/",
+    "url": "https://tesdaonlineprogram.com/how-to-apply-for-a-scholarship-in-tesda/",
     "id": "d0a43a7d-7d29-40f6-b5dc-633c97b9947d",
     "slug": "apply-for-tesda-scholarship",
     "published": true,


### PR DESCRIPTION
### Description
This pull request will update broken or outdated links for CHED scholarship, COA training, TESDA Online Program, DA eLearning, and TESDA scholarship pages.

<details><summary>Update CHED Foreign Scholarship and Training Programs' link</summary>
<br>
Updated the CHED Foreign Scholarship and Training Programs link to replace the outdated STUFAPs page with the current official CHED eGov portal UR

### Screenshot
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/218bd6a5-eb16-46e7-b581-9cb859ef525b" />

</details>

<details><summary>Update Register for a COA Training's link</summary>
<br>
Updated the COA Training link to reflect the Commission on Audit's new dedicated training portal instead of the deprecated NOM page.

### Before
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/9910fe8c-e95b-4ca7-8fdc-8380c102b2d3" />

### After
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/557275f4-dadb-4045-b844-a825ff6a3e97" />

</details>

<details><summary>Update TESDA Online Program's link</summary>
<br>

Updated the TESDA Online Program link to the new registration page, replacing the previous direct signup URL that is no longer active.

### Before
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/7bb1b9d8-1b2c-4e62-a9bc-b6c2e4afcc90" />

### After
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/ec3811f7-5768-4eaa-a6b7-bee81c413523" />


</details>

<details><summary>Update DA eLearning Certification's link</summary>
<br>
Updated the DA eLearning Certification link to the current e-Extension signup page, replacing the old e-learning portal URL.


### Screenshot
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/3ff87ec1-2e09-44f1-9994-08d2d154d306" />

</details>

<details><summary>Update TESDA Scholarship's link</summary>
<br>
The original TESDA Scholarship link currently returns an error, so it has been temporarily replaced with a TESDAOnlineProgram.com page that provides a step-by-step guide to the application process. While it also references the broken official link, it still offers accurate and helpful instructions for users.

### Screenshot
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/bf8c8303-2c58-4705-bc73-a512970bcbc8" />
</details>

### References
https://ched.e.gov.ph/foreign-scholarship-training-program
https://e-tesda.gov.ph/
https://elearn.e-extension.gov.ph/login/signup.php
https://www.coa.gov.ph/trainings/
https://tesdaonlineprogram.com/how-to-apply-for-a-scholarship-in-tesda/