### PR TITLE
fix(constitutional): read from json

### DIFF
--- a/src/pages/government/constitutional/index.tsx
+++ b/src/pages/government/constitutional/index.tsx
@@ -159,6 +159,12 @@ export default function ConstitutionalIndex() {
   if (!selectedOffice) {
     return (
       <>
+        <SEO
+          keywords={seoData.keywords}
+          canonical={seoData.canonical}
+          breadcrumbs={seoData.breadcrumbs}
+          jsonLd={seoData.jsonLd}
+        />
         <div className='@container bg-white rounded-lg border p-8 text-center h-full flex flex-col items-center justify-center'>
           <div className='mx-auto w-12 h-12 rounded-full bg-gray-50 flex items-center justify-center mb-4'>
             <Building2Icon className='h-6 w-6 text-gray-400' />
@@ -182,7 +188,12 @@ export default function ConstitutionalIndex() {
 
   return (
     <>
-      <SEO {...seoData} />
+      <SEO
+        keywords={seoData.keywords}
+        canonical={seoData.canonical}
+        breadcrumbs={seoData.breadcrumbs}
+        jsonLd={seoData.jsonLd}
+      />
       <div className='@container space-y-6'>
         <div className='flex flex-col space-y-2'>
           <div>

--- a/src/pages/government/constitutional/index.tsx
+++ b/src/pages/government/constitutional/index.tsx
@@ -159,7 +159,6 @@ export default function ConstitutionalIndex() {
   if (!selectedOffice) {
     return (
       <>
-        <SEO {...seoData} />
         <div className='@container bg-white rounded-lg border p-8 text-center h-full flex flex-col items-center justify-center'>
           <div className='mx-auto w-12 h-12 rounded-full bg-gray-50 flex items-center justify-center mb-4'>
             <Building2Icon className='h-6 w-6 text-gray-400' />


### PR DESCRIPTION
**Summary**

Removes `title` and `description` from `<SEO>` component within the constitutional page so it reads from [src/data/seo-metadata.json](https://github.com/bettergovph/bettergov/blob/main/src/data/seo-metadata.json#L46-L49).

**Screenshots**

**Before**
https://bettergov.ph/government/constitutional/civil-service-commission-csc
<img width="1175" height="81" alt="Screenshot 2025-12-08 at 9 20 19 PM" src="https://github.com/user-attachments/assets/80bde86a-17f0-4726-bc77-df989f92d601" />


**After**
Visit: https://fix-constitutional.bettergovph.pages.dev/government/constitutional/civil-service-commission-csc
<img width="1264" height="107" alt="Screenshot 2025-12-08 at 9 17 15 PM" src="https://github.com/user-attachments/assets/afe5d4b8-21b0-4c7e-b879-13d478da9e14" />
