### PR TITLE
fix(data): update population-2020 data

### DIFF
--- a/src/data/population-2020.json
+++ b/src/data/population-2020.json
@@ -43,14 +43,14 @@
       "households": 1365044
     },
     "REGION VI": {
-      "totalPopulation": 7954723,
-      "householdPopulation": 7935531,
-      "households": 1939989
+      "totalPopulation": 5331551,
+      "householdPopulation": 5316859,
+      "households": 1302022
     },
     "REGION VII": {
-      "totalPopulation": 8081988,
-      "householdPopulation": 8046285,
-      "households": 1966588
+      "totalPopulation": 6545603,
+      "householdPopulation": 6514723,
+      "households": 1592822
     },
     "NIR": {
       "totalPopulation": 4159557,


### PR DESCRIPTION
Adjust Region VI and Region VII data as a result of adding the missing data for the Negros Island Region (NIR).

Region VI (after deducting Negros Occidental):

- Total Population: 7,954,723 → 5,331,551 (-2,623,172)
- Household Population: 7,935,531 → 5,316,859 (-2,618,672)
- Households: 1,939,989 → 1,302,022 (-637,967)

Region VII (after deducting Negros Oriental and Siquijor):

- Total Population: 8,081,988 → 6,545,603 (-1,536,385)
- Household Population: 8,046,285 → 6,514,723 (-1,531,562)
- Households: 1,966,588 → 1,592,822 (-373,766)

Related to #560