### PR TITLE
Fix Executive Data (Chief Presidential Legal Counsel) from Juan Ponce Entrille to Anna Liza G. Logan

### DIFF
--- a/src/data/directory/executive.json
+++ b/src/data/directory/executive.json
@@ -89,7 +89,7 @@
         "office_division": "Office of the Chief Presidential Legal Counsel",
         "personnel": [
           {
-            "name": "JUAN F. PONCE ENRILE",
+            "name": "ANNA LIZA G. LOGAN",
             "role": "Chief Presidential Legal Counsel",
             "contact": "loc. 8468"
           },


### PR DESCRIPTION
Sources:
Logan named chief presidential legal counsel
https://newsinfo.inquirer.net/2155765/logan-named-chief-presidential-legal-counsel

Before:

<img width="493" height="321" alt="image" src="https://github.com/user-attachments/assets/409c8842-498c-493e-87fa-8eeaf3b55def" />

After:

<img width="359" height="259" alt="image" src="https://github.com/user-attachments/assets/e24f2e7f-26f7-4ee4-817c-6bc5ca6c1418" />
