### PR TITLE
Fix navbar overflow on desktop view

### DIFF
--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -124,7 +124,7 @@ const Navbar: FC = () => {
   if (location.pathname === '/philippines/map') return null;
 
   return (
-    <nav className='bg-white shadow-xs sticky top-0 z-50'>
+    <nav className='bg-white shadow-xs sticky top-0 z-50 overflow-x-hidden'>
       {/* Top bar with language switcher and additional links */}
       <div className='border-b border-gray-200'>
         <div className='container mx-auto px-4 flex justify-center md:justify-end'>
@@ -182,7 +182,7 @@ const Navbar: FC = () => {
       {/* Main navigation */}
       <div className='container mx-auto px-4'>
         <div className='flex justify-between items-center py-4'>
-          <div className='flex items-center'>
+          <div className='flex items-center shrink-0'>
             <Link to='/' className='flex items-center'>
               <img
                 src='/logos/svg/BetterGov_Icon-Primary.svg'
@@ -199,7 +199,7 @@ const Navbar: FC = () => {
           </div>
 
           {/* Desktop navigation */}
-          <div className='hidden lg:flex items-center lg:space-x-4 xl:space-x-8 lg:pr-6 xl:pr-24 lg:leading-10'>
+          <div className='hidden lg:flex items-center min-w-0 lg:space-x-1 xl:space-x-3 2xl:space-x-6 lg:leading-10'>
             {mainNavigation.map(item => {
               const isActive = isActiveRoute(item.href);
               return (
@@ -217,10 +217,12 @@ const Navbar: FC = () => {
                         : 'text-gray-700 hover:text-primary-600 border-transparent'
                     }`}
                   >
-                    {t(`navbar.${item.label.toLowerCase()}`)}
+                    <span className='lg:text-sm xl:text-base'>
+                      {t(`navbar.${item.label.toLowerCase()}`)}
+                    </span>
                     {item.children && (
                       <ChevronDownIcon
-                        className={`ml-1 h-4 w-4 transition-colors ${
+                        className={`ml-1 h-4 w-4 shrink-0 transition-colors ${
                           isActive
                             ? 'text-primary-600'
                             : 'text-gray-800 group-hover:text-primary-600'
@@ -263,12 +265,12 @@ const Navbar: FC = () => {
               );
             })}
           </div>
-          <div className='hidden lg:flex items-center lg:space-x-4 xl:space-x-8 lg:pr-6 xl:pr-24 lg:leading-10'>
+          <div className='hidden lg:flex items-center shrink-0 lg:leading-10'>
             <Link
               to='/search'
-              className='flex items-center text-gray-700 hover:text-primary-600 font-semibold text-lg transition-colors px-3 py-2 rounded-lg hover:bg-gray-50'
+              className='flex items-center text-gray-700 hover:text-primary-600 font-semibold lg:text-base xl:text-lg transition-colors px-3 py-2 rounded-lg hover:bg-gray-50 whitespace-nowrap'
             >
-              <SearchIcon className='h-5 w-5 mr-2' />
+              <SearchIcon className='h-5 w-5 mr-2 shrink-0' />
               Search
             </Link>
             {/* <Link


### PR DESCRIPTION
Style changed `Navbar.tsx`:
- Nav: add `overflow-x-hidden`
- Main Nav Container: add `shrink-0` to the logo wrapper div
- Desktop Nav Container: reduce nav spacing to `lg:space-x-1 xl:space-x-3 2xl:space-x-6` and removed right padding
- Icons Loop: add `shrink-0`

Before:
<img width="801" height="301" alt="image" src="https://github.com/user-attachments/assets/05576163-4b3c-4850-aca2-e2471e1e81b9" />

After:
<img width="1395" height="188" alt="image" src="https://github.com/user-attachments/assets/214f82f2-815c-45d2-bbf3-6b5ea9f8c481" />


