### PR TITLE
fix: replace overflow-x-hidden with overflow-x-clip in Navbar to prevent scrollbar issue

### DIFF
--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -124,7 +124,7 @@ const Navbar: FC = () => {
   if (location.pathname === '/philippines/map') return null;
 
   return (
-    <nav className='bg-white shadow-xs sticky top-0 z-50 overflow-x-hidden'>
+    <nav className='bg-white shadow-xs sticky top-0 z-50 overflow-x-clip'>
       {/* Top bar with language switcher and additional links */}
       <div className='border-b border-gray-200'>
         <div className='container mx-auto px-4 flex justify-center md:justify-end'>


### PR DESCRIPTION
## Description

Replace `overflow-x-hidden` with `overflow-x-clip` in navigation bar to prevent scrollbar issue.

## Before

### Google Chrome

https://github.com/user-attachments/assets/25eeb9ef-d207-4388-b9c9-7466a2620f2a

### Firefox

https://github.com/user-attachments/assets/2623b028-1969-4847-9c1a-d844b8d31121

## After

### Google Chrome

https://github.com/user-attachments/assets/d1c7969f-f0ad-49ca-9766-82512662c8d0


### Firefox

https://github.com/user-attachments/assets/69c6fe4b-d038-44af-96f7-2638a8621a20



