### PR TITLE
fix: safari navbar hover

### DIFF
--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -251,6 +251,9 @@ const Navbar: FC = () => {
                   </Link>
                   {item.children && (
                     <div
+                      style={{
+                        WebkitTransform: 'translate3d(0,0,0)',
+                      }}
                       className={`absolute left-0 w-56 rounded-md shadow-lg bg-white ring-1 ring-black/5 transition-[opacity] duration-200 z-50 pt-2 ${
                         hoveredDropdown === item.label
                           ? 'opacity-100 visible pointer-events-auto'


### PR DESCRIPTION
**Summary**
Resets safari's stacking context for the parent menu element to ensure z-index gets applied.

**Testing**
1. Go to [preview URL](https://d5e42733-bettergovph.bettergov.workers.dev/) using Safari
2. Hover over the menu item
3. Should not see the menu item flicker

See: 
**Before**
https://github.com/user-attachments/assets/3ebddcac-5d8e-4ff4-9a72-a9d2bf35be20

**After**
https://github.com/user-attachments/assets/622ac66c-51f4-43b5-a697-048e2ef5ce4d

