### PR TITLE
feat: add Better LGU link to Our Projects dropdown

### DIFF
--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -23,6 +23,11 @@ export const ourProjects = [
         target: '_blank',
       },
       {
+        label: 'Better LGU',
+        href: 'https://lgu.bettergov.ph/',
+        target: '_blank',
+      },
+      {
         label: 'Budget Tracker',
         href: 'https://budget.bettergov.ph',
         target: '_blank',


### PR DESCRIPTION
Inserts a new 'Better LGU' submenu item in the 'Our Projects' navigation dropdown, positioned immediately before 'Budget Tracker'. The link opens https://lgu.bettergov.ph/ in a new tab.

<img width="241" height="589" alt="Screenshot 2026-05-06 at 12 44 15 AM" src="https://github.com/user-attachments/assets/1675f07c-f9d1-4a41-ac88-dc8a12502e67" />
