### PR TITLE
fix(e2e-test): updates for Build and Test workflow

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -63,7 +63,7 @@ jobs:
     name: Playwright Tests (Shard ${{ matrix.shardIndex }}/${{ matrix.shardTotal }})
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.55.0-noble
+      image: mcr.microsoft.com/playwright:v1.59.1-noble
       options: --user 1001
     strategy:
       fail-fast: false

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -26,7 +26,7 @@ jobs:
       # (a) performs the npm run build when building the image, and
       # (b) acts as a placeholder if we want to deploy as a container in the future.
       - name: Build the image
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           platforms: linux/amd64
@@ -99,7 +99,7 @@ jobs:
           fi
 
       - name: Upload blob report
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ !cancelled() }}
         with:
           name: blob-report-${{ matrix.shardIndex }}
@@ -125,7 +125,7 @@ jobs:
         run: npm install @playwright/test
 
       - name: Download all blob reports
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: all-reports
           pattern: blob-report-*
@@ -145,7 +145,7 @@ jobs:
           fi
 
       - name: Upload merged Playwright report
-        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: playwright-report
           path: playwright-report/

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -70,10 +70,10 @@ test.describe('Navigation', () => {
     // Scroll to footer
     await page.locator('footer').scrollIntoViewIfNeeded();
 
-    // Test About link
+    // Test About the Portal link
     const aboutLink = page
       .locator('footer')
-      .getByRole('link', { name: 'About' });
+      .getByRole('link', { name: 'About the Portal' });
     await expect(aboutLink).toBeVisible();
     await aboutLink.click();
     expect(page.url()).toContain('/about');

--- a/src/components/ui/SearchInput.tsx
+++ b/src/components/ui/SearchInput.tsx
@@ -2,8 +2,10 @@ import { SearchIcon, XIcon } from 'lucide-react';
 import { ChangeEvent, FormEvent, InputHTMLAttributes, ReactNode } from 'react';
 import { cn } from '../../lib/utils';
 
-interface SearchInputProps
-  extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size'> {
+interface SearchInputProps extends Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  'size'
+> {
   onSearch?: (value: string) => void;
   className?: string;
   placeholder?: string;

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -163,6 +163,7 @@ export const footerNavigation = {
     {
       title: 'About',
       links: [
+        { label: 'About the Portal', href: '/about' },
         { label: 'About BetterGov.ph', href: 'https://about.bettergov.ph' },
         { label: 'Documentation', href: 'https://docs.bettergov.ph/' },
         { label: 'Project Ideas', href: '/ideas' },

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -163,7 +163,6 @@ export const footerNavigation = {
     {
       title: 'About',
       links: [
-        { label: 'About the Portal', href: '/about' },
         { label: 'About BetterGov.ph', href: 'https://about.bettergov.ph' },
         { label: 'Documentation', href: 'https://docs.bettergov.ph/' },
         { label: 'Project Ideas', href: '/ideas' },


### PR DESCRIPTION
Resolves #639 by upgrading Playwright CI version, addressing a linter warning, and updating a footer test case.

### Summary of changes
- Upgrade Playwright used in workflow from 1.55.0 to 1.59.1
- Format [`/src/components/ui/SearchInput.tsx`](https://github.com/bettergovph/bettergov/compare/main...jrpdango:bettergov:fix/build-and-test-ci?expand=1#diff-5176876c38023dfb87fab4f0efe4c7fbf3d39dc75d0dc7db3f2a86f19d83e1c3) to fix linter warning
- Update [`e2e/navigation.spec.ts`](https://github.com/bettergovph/bettergov/compare/main...jrpdango:bettergov:fix/build-and-test-ci?expand=1#diff-7427646228c799f1d2ab89ef8ca0ba4b7466ec4a6b1a50ec38ef74b0e063067b) test case to more specifically locate the original "About the Portal" link
- Additionally bump versions of the following actions used in the workflow to suppress warnings of Node 20 actions being deprecated:
  - docker/build-push-action v6.18.0 --> v7.1.0
  - actions/upload-artifact v5.0.0 --> v7.0.1
  - actions/download-artifact v6.0.0 --> v8.0.1