### PR TITLE
fix(services): update PSA Serbilis certificate links

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -5,6 +5,11 @@ const buildEslintCommand = filenames =>
     .map(f => `"${path.relative(process.cwd(), f)}"`)
     .join(' ')}`;
 
+const buildValidateCommand = schemaPath => filenames =>
+  `node scripts/validate-json-schema.js ${schemaPath} ${filenames
+    .map(f => `"${path.relative(process.cwd(), f)}"`)
+    .join(' ')}`;
+
 const config = {
   // ESLint for JavaScript/TypeScript files (including .cjs and .mjs)
   '*.{js,jsx,ts,tsx,cjs,mjs}': [buildEslintCommand],
@@ -15,44 +20,63 @@ const config = {
   ],
 
   // JSON Schema validation for data files
-  'src/data/directory/lgu/*.json': filenames =>
-    `node scripts/validate-json-schema.js src/data/directory/lgu/schema/lgu-region.schema.json ${filenames.join(' ')}`,
-  'src/data/directory/constitutional.json': filenames =>
-    `node scripts/validate-json-schema.js src/data/directory/schema/constitutional.schema.json ${filenames.join(' ')}`,
-  'src/data/directory/departments.json': filenames =>
-    `node scripts/validate-json-schema.js src/data/directory/schema/departments.schema.json ${filenames.join(' ')}`,
-  'src/data/directory/diplomatic.json': filenames =>
-    `node scripts/validate-json-schema.js src/data/directory/schema/diplomatic.schema.json ${filenames.join(' ')}`,
-  'src/data/directory/executive.json': filenames =>
-    `node scripts/validate-json-schema.js src/data/directory/schema/executive.schema.json ${filenames.join(' ')}`,
-  'src/data/directory/house_members.json': filenames =>
-    `node scripts/validate-json-schema.js src/data/directory/schema/house_members.schema.json ${filenames.join(' ')}`,
-  'src/data/directory/legislative.json': filenames =>
-    `node scripts/validate-json-schema.js src/data/directory/schema/legislative.schema.json ${filenames.join(' ')}`,
-  'src/data/directory/party_list_representatives.json': filenames =>
-    `node scripts/validate-json-schema.js src/data/directory/schema/party_list_representatives.schema.json ${filenames.join(' ')}`,
-  'src/data/services/*.json': filenames =>
-    `node scripts/validate-json-schema.js src/data/services/schema/services.schema.json ${filenames.join(' ')}`,
-  'src/data/philippines-regions.json': filenames =>
-    `node scripts/validate-json-schema.js src/data/schema/GeoJSON.json ${filenames.join(' ')}`,
-  'src/data/philippines_hotlines.json': filenames =>
-    `node scripts/validate-json-schema.js src/data/schema/philippines_hotlines.schema.json ${filenames.join(' ')}`,
-  'src/data/population-2020.json': filenames =>
-    `node scripts/validate-json-schema.js src/data/schema/population-2020.schema.json ${filenames.join(' ')}`,
-  'src/data/regions.json': filenames =>
-    `node scripts/validate-json-schema.js src/data/schema/regions.schema.json ${filenames.join(' ')}`,
-  'src/data/seo-metadata.json': filenames =>
-    `node scripts/validate-json-schema.js src/data/schema/seo-metadata.schema.json ${filenames.join(' ')}`,
-  'src/data/service_categories.json': filenames =>
-    `node scripts/validate-json-schema.js src/data/schema/service_categories.schema.json ${filenames.join(' ')}`,
-  'src/data/websites.json': filenames =>
-    `node scripts/validate-json-schema.js src/data/schema/websites.schema.json ${filenames.join(' ')}`,
-  'src/data/flood_control/flood_control.json': filenames =>
-    `node scripts/validate-json-schema.js src/data/flood_control/schema/flood_control.schema.json ${filenames.join(' ')}`,
-  'src/data/visa/philippines_visa_policy.json': filenames =>
-    `node scripts/validate-json-schema.js src/data/visa/schema/philippines_visa_policy.schema.json ${filenames.join(' ')}`,
-  'src/data/visa/philippines_visa_types.json': filenames =>
-    `node scripts/validate-json-schema.js src/data/visa/schema/philippines_visa_types.schema.json ${filenames.join(' ')}`,
+  'src/data/directory/lgu/*.json': buildValidateCommand(
+    'src/data/directory/lgu/schema/lgu-region.schema.json'
+  ),
+  'src/data/directory/constitutional.json': buildValidateCommand(
+    'src/data/directory/schema/constitutional.schema.json'
+  ),
+  'src/data/directory/departments.json': buildValidateCommand(
+    'src/data/directory/schema/departments.schema.json'
+  ),
+  'src/data/directory/diplomatic.json': buildValidateCommand(
+    'src/data/directory/schema/diplomatic.schema.json'
+  ),
+  'src/data/directory/executive.json': buildValidateCommand(
+    'src/data/directory/schema/executive.schema.json'
+  ),
+  'src/data/directory/house_members.json': buildValidateCommand(
+    'src/data/directory/schema/house_members.schema.json'
+  ),
+  'src/data/directory/legislative.json': buildValidateCommand(
+    'src/data/directory/schema/legislative.schema.json'
+  ),
+  'src/data/directory/party_list_representatives.json': buildValidateCommand(
+    'src/data/directory/schema/party_list_representatives.schema.json'
+  ),
+  'src/data/services/*.json': buildValidateCommand(
+    'src/data/services/schema/services.schema.json'
+  ),
+  'src/data/philippines-regions.json': buildValidateCommand(
+    'src/data/schema/GeoJSON.json'
+  ),
+  'src/data/philippines_hotlines.json': buildValidateCommand(
+    'src/data/schema/philippines_hotlines.schema.json'
+  ),
+  'src/data/population-2020.json': buildValidateCommand(
+    'src/data/schema/population-2020.schema.json'
+  ),
+  'src/data/regions.json': buildValidateCommand(
+    'src/data/schema/regions.schema.json'
+  ),
+  'src/data/seo-metadata.json': buildValidateCommand(
+    'src/data/schema/seo-metadata.schema.json'
+  ),
+  'src/data/service_categories.json': buildValidateCommand(
+    'src/data/schema/service_categories.schema.json'
+  ),
+  'src/data/websites.json': buildValidateCommand(
+    'src/data/schema/websites.schema.json'
+  ),
+  'src/data/flood_control/flood_control.json': buildValidateCommand(
+    'src/data/flood_control/schema/flood_control.schema.json'
+  ),
+  'src/data/visa/philippines_visa_policy.json': buildValidateCommand(
+    'src/data/visa/schema/philippines_visa_policy.schema.json'
+  ),
+  'src/data/visa/philippines_visa_types.json': buildValidateCommand(
+    'src/data/visa/schema/philippines_visa_types.schema.json'
+  ),
 
   // JSON schema validation for the project registry
   'public/api/projects.json': [

--- a/src/data/services/certificates-ids.json
+++ b/src/data/services/certificates-ids.json
@@ -37,7 +37,7 @@
   },
   {
     "service": "Request a Birth Certificate via PSA Serbilis",
-    "url": "https://www.psaserbilis.com.ph/Census/BirthCertificate",
+    "url": "https://www.psaserbilis.com.ph/BirthCertificate",
     "id": "3f6e4e39-1c64-471a-8a05-c79cb186325a",
     "slug": "request-a-birth-certificate-via-psa-serbilis",
     "published": true,
@@ -73,7 +73,7 @@
   },
   {
     "service": "Request a Certificate of No Marriage Record (CENOMAR) via PSA Serbilis",
-    "url": "https://www.psaserbilis.com.ph/Census/CENOMARCertificate",
+    "url": "https://www.psaserbilis.com.ph/CENOMARCertificate",
     "id": "e4f3ea9f-8e61-4458-b746-f4b7537a47b1",
     "slug": "request-a-certificate-of-no-marriage-record-cenomar-via-psa-serbilis",
     "published": true,
@@ -106,6 +106,60 @@
     },
     "createdAt": "2025-06-06T11:30:06.318Z",
     "updatedAt": "2025-06-06T11:30:06.318Z"
+  },
+  {
+    "service": "Request a Death Certificate via PSA Serbilis",
+    "url": "https://www.psaserbilis.com.ph/DeathCertificate",
+    "id": "8a9d4763-1235-4952-a713-ca283053900a",
+    "slug": "request-a-death-certificate-via-psa-serbilis",
+    "published": true,
+    "featured": false,
+    "category": {
+      "name": "Certificates and IDs",
+      "slug": "certificates-ids"
+    },
+    "subcategory": {
+      "name": "Certificates",
+      "slug": "certificates"
+    },
+    "createdAt": "2026-06-13T00:00:00.000Z",
+    "updatedAt": "2026-06-13T00:00:00.000Z"
+  },
+  {
+    "service": "Request a Marriage Certificate via PSA Serbilis",
+    "url": "https://www.psaserbilis.com.ph/MarriageCertificate",
+    "id": "8b8eb183-72e1-41d9-bba1-405f7d4b9584",
+    "slug": "request-a-marriage-certificate-via-psa-serbilis",
+    "published": true,
+    "featured": false,
+    "category": {
+      "name": "Certificates and IDs",
+      "slug": "certificates-ids"
+    },
+    "subcategory": {
+      "name": "Certificates",
+      "slug": "certificates"
+    },
+    "createdAt": "2026-06-13T00:00:00.000Z",
+    "updatedAt": "2026-06-13T00:00:00.000Z"
+  },
+  {
+    "service": "Request a Certificate of No Death Record (CENODEATH) via PSA Serbilis",
+    "url": "https://www.psaserbilis.com.ph/CENODEATHCertificate",
+    "id": "7708246d-9e02-4932-9fb3-9e051a2e0dd2",
+    "slug": "request-a-certificate-of-no-death-record-cenodeath-via-psa-serbilis",
+    "published": true,
+    "featured": false,
+    "category": {
+      "name": "Certificates and IDs",
+      "slug": "certificates-ids"
+    },
+    "subcategory": {
+      "name": "Certificates",
+      "slug": "certificates"
+    },
+    "createdAt": "2026-06-13T00:00:00.000Z",
+    "updatedAt": "2026-06-13T00:00:00.000Z"
   },
   {
     "service": "Request a Death Certificate via PSAHelpline.ph",

--- a/src/data/services/certificates-ids.json
+++ b/src/data/services/certificates-ids.json
@@ -122,8 +122,8 @@
       "name": "Certificates",
       "slug": "certificates"
     },
-    "createdAt": "2026-06-13T00:00:00.000Z",
-    "updatedAt": "2026-06-13T00:00:00.000Z"
+    "createdAt": "2026-06-13T05:46:14Z",
+    "updatedAt": "2026-06-13T05:46:14Z"
   },
   {
     "service": "Request a Marriage Certificate via PSA Serbilis",
@@ -140,8 +140,8 @@
       "name": "Certificates",
       "slug": "certificates"
     },
-    "createdAt": "2026-06-13T00:00:00.000Z",
-    "updatedAt": "2026-06-13T00:00:00.000Z"
+    "createdAt": "2026-06-13T05:46:14Z",
+    "updatedAt": "2026-06-13T05:46:14Z"
   },
   {
     "service": "Request a Certificate of No Death Record (CENODEATH) via PSA Serbilis",
@@ -158,8 +158,8 @@
       "name": "Certificates",
       "slug": "certificates"
     },
-    "createdAt": "2026-06-13T00:00:00.000Z",
-    "updatedAt": "2026-06-13T00:00:00.000Z"
+    "createdAt": "2026-06-13T05:46:14Z",
+    "updatedAt": "2026-06-13T05:46:14Z"
   },
   {
     "service": "Request a Death Certificate via PSAHelpline.ph",


### PR DESCRIPTION
## Fix PSA Serbilis links and add missing certificate entries

Fixes #653 

## Changes

- Fixed broken PSA Serbilis links for Birth Certificate and CENOMAR. Both previously included a `/Census/` path segment that no longer exists on the site, causing a blank page.
- Added 3 other PSA Serbilis entries: Death Certificate, Marriage Certificate, and CENODEATH.

### `.lintstagedrc.js` Refactor

- Added a shared `buildValidateCommand` helper. This fixes a bug where filenames with spaces in their path (in my case, my filepath was `C:\Users\Elijah Patrick\...`) broke the pre-commit JSON schema validation with `Invalid JSON - Expected ',' or ']' after array element`.

## Testing

- Verified all PSA Serbilis URLs resolve correctly
- Confirmed new entries appear in search after a dev server restart
- I am able to commit which led to this very PR hehe