### PR TITLE
feat: Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,40 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG]: "
+labels: bug
+assignees: ''
+type: Bug
+
+---
+
+**Describe the bug**:
+<!-- A clear and concise description of what the bug is. -->
+
+
+**To Reproduce**:
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**:
+<!-- A clear and concise description of what you expected to happen. -->
+
+
+**Screenshots**:
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+
+**Device Info** (optional):
+<!-- Please add the following details if it adds context to the problem -->
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Additional context**:
+<!-- Add any other context about the problem here. -->
+
+**Screenshots**:
+<!-- Put you screenshots below this -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,21 +1,24 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: "[FEATURE]:"
+title: "[FEATURE]: "
 labels: enhancement
 assignees: ''
 type: Feature
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+**Description**:
+Provide a clear and concise description of what feature you want to add or implemented.
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+**Motivation**:
+Explain why you want this added. A clear and concise description of why you want this implemented.
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+**Proposed Implementation** (optional):
+How will this be built/implemented?
 
-**Additional context**
+**Benefits**:
+Who will benefit with this feature?
+
+**Additional context / References / Examples**:
 Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[FEATURE]:"
+labels: enhancement
+assignees: ''
+type: Feature
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/give_task.md
+++ b/.github/ISSUE_TEMPLATE/give_task.md
@@ -1,0 +1,11 @@
+---
+name: What task needs to be done
+about: Give contributors a task do be done.
+title: "[TASK]: "
+labels: enhancement
+assignees: ''
+type: Task
+
+---
+
+<!-- Describe the task here -->

--- a/.github/ISSUE_TEMPLATE/share-your-idea.md
+++ b/.github/ISSUE_TEMPLATE/share-your-idea.md
@@ -1,0 +1,11 @@
+---
+name: Share your Idea
+about: Share your ideas for BetterGov
+title: "[IDEA]: "
+labels: enhancement
+assignees: ''
+type: Feature
+
+---
+
+<!-- Describe your idea here -->

--- a/.github/ISSUE_TEMPLATE/share-your-idea.md
+++ b/.github/ISSUE_TEMPLATE/share-your-idea.md
@@ -2,7 +2,7 @@
 name: Share your Idea
 about: Share your ideas for BetterGov
 title: "[IDEA]: "
-labels: enhancement
+labels: idea
 assignees: ''
 type: Feature
 


### PR DESCRIPTION
fixes #622 
---
Adds an issue template for github issue creation
>No GitHub Issue Templates: The .github directory only contains workflows, dependabot.yml , and actionlint-matcher.json — no structured issue/PR templates exist yet. Contributors rely on the CONTRIBUTING.md guidelines.