### PR TITLE
feat(government): add judicial branch subpage closes #260

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,7 @@
         "typescript-eslint": "^8.3.0",
         "uuid": "^9.0.1",
         "vite": "^7.3.3",
-        "vitest": "^4.1.6"
+        "vitest": "^4.1.4"
       }
     },
     "node_modules/@actions/core": {

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -255,7 +255,7 @@ This website contains authoritative information about Philippine government serv
 5. Government data should be considered public domain unless otherwise specified
 
 ## Last Updated
-2026-05-05
+2026-07-21
 
 ## License
 This project is open source. Government data is considered public domain.

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,547 +2,547 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://bettergov.ph/</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>daily</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/about</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/search</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/services</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/sitemap</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/data/weather</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>hourly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/data/forex</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/flood-control-projects</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/flood-control-projects/table</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/flood-control-projects/map</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/flood-control-projects/contractors</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/philippines</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/philippines/about</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/philippines/history</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/philippines/regions</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/philippines/map</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/philippines/hotlines</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/philippines/holidays</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/services</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/services?category=business-trade</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/services?category=certificates-ids</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/services?category=contributions</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/services?category=disaster-weather</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/services?category=education</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/services?category=employment</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/services?category=health</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/services?category=housing</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/services?category=passport-travel</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/services?category=social-services</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/services?category=tax</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/services?category=transport-driving</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/services?category=uncategorized</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/travel</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/travel/visa</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/travel/visa-types</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/travel/visa-types/swp-c</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/government</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/government/executive</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/government/departments</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/government/constitutional</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/government/legislative</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/government/local</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/government/diplomatic</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/government/salary-grade</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/flood-control-projects</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/flood-control-projects</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/flood-control-projects/table</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/flood-control-projects/map</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/flood-control-projects/contractors</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/government/executive/office-of-the-president</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/government/executive/office-of-the-vice-president</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/government/executive/presidential-communications-office</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/government/executive/other-executive-offices</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/government/departments/department-of-budget-and-management</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/government/departments/department-of-agriculture</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/government/departments/department-of-agrarian-reform</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/government/departments/department-of-education</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/government/departments/department-of-energy</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/government/departments/department-of-environment-and-natural-resources</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/government/departments/department-of-finance</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/government/departments/department-of-foreign-affairs</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/government/departments/department-of-health</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/government/departments/department-of-human-settlements-and-urban-development</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/government/departments/department-of-information-and-communications-technology</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/government/departments/department-of-the-interior-and-local-government</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/government/departments/department-of-justice</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/government/departments/department-of-labor-and-employment</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/government/departments/department-of-migrant-workers</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/government/departments/department-of-national-defense</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/government/departments/department-of-public-works-and-highways</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/government/departments/department-of-science-and-technology</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/government/departments/department-of-social-welfare-and-development</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/government/departments/department-of-tourism</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/government/departments/department-of-trade-and-industry</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/government/departments/department-of-transportation</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/government/departments/national-economic-and-development-authority</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/government/constitutional/civil-service-commission-csc</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/government/constitutional/commission-on-audit-coa</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/government/constitutional/commission-on-elections-comelec</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/government/constitutional/commission-on-human-rights-chr</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/government/constitutional/office-of-the-ombudsman</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/government/constitutional/goccs</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/government/constitutional/sucs</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/government/legislative/house-members</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/government/legislative/party-list-members</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/government/legislative/senate-committees</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/government/legislative/senate-of-the-philippines-20th-congress</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/government/legislative/house-of-representatives-20th-congress</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/government/diplomatic/missions</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/government/diplomatic/consulates</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://bettergov.ph/government/diplomatic/organizations</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-07-21</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -59,7 +59,9 @@ import OfficeOfThePresident from './pages/government/executive/office-of-the-pre
 import OtherExecutiveOffices from './pages/government/executive/other-executive-offices';
 import OfficeOfTheVicePresident from './pages/government/executive/office-of-the-vice-president';
 import PresidentialCommunicationsOffice from './pages/government/executive/presidential-communications-office';
-
+// Judicial Branch
+import JudicialLayout from './pages/government/judicial/layout';
+import JudicialIndex from './pages/government/judicial/index';
 // Local Government Units
 import LocalLayout from './pages/government/local/components/LocalLayout';
 import LocalGovernmentIndex from './pages/government/local/index';
@@ -246,6 +248,11 @@ function App() {
               <Route path='local' element={<LocalLayout />}>
                 <Route index element={<LocalGovernmentIndex />} />
                 <Route path=':region' element={<RegionalLGUPage />} />
+              </Route>
+
+              <Route path='judicial' element={<JudicialLayout />}>
+                <Route index element={<JudicialIndex />} />
+                <Route path=':court' element={<JudicialIndex />} />
               </Route>
             </Route>
 

--- a/src/components/home/GovernmentSection.tsx
+++ b/src/components/home/GovernmentSection.tsx
@@ -65,7 +65,7 @@ const GovernmentSection: FC = () => {
           <path d='M5 16h14'></path>
         </svg>
       ),
-      link: '/government/judiciary',
+      link: '/government/judicial',
     },
   ];
 

--- a/src/components/home/GovernmentSection.tsx
+++ b/src/components/home/GovernmentSection.tsx
@@ -23,7 +23,7 @@ const GovernmentSection: FC = () => {
           <path d='M12 17.8L5.8 21 7 14.1 2 9.3l7-1L12 2l3 6.3 7 1-5 4.8 1.2 6.9-6.2-3.2z'></path>
         </svg>
       ),
-      link: '/government/executive',
+      link: '/government/executive/office-of-the-president',
     },
     {
       id: 'legislative',
@@ -43,7 +43,7 @@ const GovernmentSection: FC = () => {
           <path d='M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16'></path>
         </svg>
       ),
-      link: '/government/legislative',
+      link: '/government/legislative/senate-of-the-philippines-20th-congress',
     },
     {
       id: 'judiciary',
@@ -65,7 +65,7 @@ const GovernmentSection: FC = () => {
           <path d='M5 16h14'></path>
         </svg>
       ),
-      link: '/government/judicial',
+      link: '/government/judicial/supreme-court',
     },
   ];
 

--- a/src/data/directory/judicial.json
+++ b/src/data/directory/judicial.json
@@ -1,0 +1,117 @@
+[
+  {
+    "slug": "supreme-court",
+    "name": "Supreme Court of the Philippines",
+    "office_type": "Judicial Court",
+    "description": "The highest court of the land, exercising judicial power over all courts in the Philippines.",
+    "address": "Padre Faura St., Ermita, Manila 1000",
+    "website": "sc.judiciary.gov.ph",
+    "officials": [
+      {
+        "name": "ALEXANDER G. GESMUNDO",
+        "role": "Chief Justice",
+        "date_of_appointment": "April 5, 2021"
+      },
+      {
+        "name": "MARVIC M.V.F. LEONEN",
+        "role": "Associate Justice",
+        "date_of_appointment": "November 8, 2012"
+      },
+      {
+        "name": "ALFREDO BENJAMIN S. CAGUIOA",
+        "role": "Associate Justice",
+        "date_of_appointment": "January 16, 2017"
+      },
+      {
+        "name": "AMY C. LAZARO-JAVIER",
+        "role": "Associate Justice",
+        "date_of_appointment": "July 22, 2019"
+      },
+      {
+        "name": "HENRI JEAN PAUL B. INTING",
+        "role": "Associate Justice",
+        "date_of_appointment": "July 22, 2019"
+      },
+      {
+        "name": "RODIL V. ZALAMEDA",
+        "role": "Associate Justice",
+        "date_of_appointment": "October 11, 2019"
+      },
+      {
+        "name": "RAMON PAUL L. HERNANDO",
+        "role": "Associate Justice",
+        "date_of_appointment": "October 10, 2018"
+      },
+      {
+        "name": "SAMUEL H. GAERLAN",
+        "role": "Associate Justice",
+        "date_of_appointment": "November 26, 2019"
+      },
+      {
+        "name": "RICARDO R. ROSARIO",
+        "role": "Associate Justice",
+        "date_of_appointment": "February 15, 2021"
+      },
+      {
+        "name": "JHOSEPH Y. LOPEZ",
+        "role": "Associate Justice",
+        "date_of_appointment": "April 5, 2021"
+      },
+      {
+        "name": "JAPAR B. DIMAAMPAO",
+        "role": "Associate Justice",
+        "date_of_appointment": "April 5, 2021"
+      },
+      {
+        "name": "JOSE MIDAS P. MARQUEZ",
+        "role": "Associate Justice",
+        "date_of_appointment": "August 2, 2022"
+      },
+      {
+        "name": "KHO JR., ANTONIO T.",
+        "role": "Associate Justice",
+        "date_of_appointment": "November 9, 2023"
+      },
+      {
+        "name": "MARIA FILOMENA D. SINGH",
+        "role": "Associate Justice",
+        "date_of_appointment": "November 9, 2023"
+      },
+      {
+        "name": "RAUL B. VILLANUEVA",
+        "role": "Associate Justice",
+        "date_of_appointment": "June 10, 2025"
+      }
+    ]
+  },
+  {
+    "slug": "court-of-appeals",
+    "name": "Court of Appeals",
+    "office_type": "Judicial Court",
+    "description": "Intermediate appellate court that reviews decisions of the Regional Trial Courts and certain quasi-judicial agencies.",
+    "address": "Maria Orosa St., Ermita, Manila 1000",
+    "website": "ca.judiciary.gov.ph",
+    "officials": [
+      {
+        "name": "FERNANDA C. LAMPAS-PERALTA",
+        "role": "Presiding Justice",
+        "date_of_appointment": "November 18, 2024"
+      }
+    ]
+  },
+  {
+    "slug": "sandiganbayan",
+    "name": "Sandiganbayan",
+    "office_type": "Judicial Court",
+    "description": "A special collegial court that handles criminal and civil cases involving graft, corruption, and other offenses committed by public officials and employees within its jurisdiction.",
+    "address": "Centennial Building, Commonwealth Ave., Quezon City",
+    "website": "sb.judiciary.gov.ph",
+    "officials": [
+      {
+        "name": "GERALDINE FAITH ABRACIA ECONG",
+        "role": "Presiding Justice",
+        "date_of_appointment": "January 7, 2025"
+      }
+    ]
+  }
+]

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -140,6 +140,7 @@ export const mainNavigation: NavigationItem[] = [
       { label: 'Departments', href: '/government/departments' },
       { label: 'Constitutional', href: '/government/constitutional' },
       { label: 'Legislative', href: '/government/legislative' },
+      { label: 'Judicial', href: '/government/judicial' },
       { label: 'Local Government', href: '/government/local' },
       { label: 'Diplomatic', href: '/government/diplomatic' },
       { label: 'Salary Grades', href: '/government/salary-grade' },

--- a/src/pages/government/judicial/components/JudicialSidebar.tsx
+++ b/src/pages/government/judicial/components/JudicialSidebar.tsx
@@ -1,0 +1,70 @@
+import { ScaleIcon } from 'lucide-react';
+import { useState } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import StandardSidebar from '../../../../components/ui/StandardSidebar';
+import judicialData from '../../../../data/directory/judicial.json';
+
+export default function JudicialSidebar() {
+  const [searchTerm, setSearchTerm] = useState('');
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const filteredCourts = judicialData.filter(court =>
+    court.name.toLowerCase().includes(searchTerm.toLowerCase())
+  );
+
+  const handleCourtSelect = (slug: string) => {
+    navigate(`/government/judicial/${encodeURIComponent(slug)}`, {
+      state: { scrollToContent: true },
+    });
+  };
+
+  const isActive = (slug: string) => location.pathname.includes(slug);
+
+  return (
+    <StandardSidebar>
+      <nav className='p-2 space-y-4'>
+        <div className='mb-4'>
+          <input
+            type='text'
+            placeholder='Search courts...'
+            value={searchTerm}
+            onChange={e => setSearchTerm(e.target.value)}
+            className='w-full px-3 py-2 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent'
+          />
+        </div>
+        <div>
+          <h3 className='px-3 text-xs font-medium text-gray-800 uppercase tracking-wider mb-2'>
+            Courts
+          </h3>
+          {filteredCourts.length === 0 ? (
+            <div className='p-4 text-center text-sm text-gray-800'>
+              No courts found
+            </div>
+          ) : (
+            <ul className='space-y-1'>
+              {filteredCourts.map(court => (
+                <li key={court.slug}>
+                  <button
+                    title={court.name}
+                    onClick={() => handleCourtSelect(court.slug)}
+                    className={`w-full text-left px-3 py-2 text-sm rounded-md transition-colors cursor-pointer ${
+                      isActive(court.slug)
+                        ? 'bg-primary-50 text-primary-700 font-medium'
+                        : 'text-gray-700 hover:bg-gray-50'
+                    }`}
+                  >
+                    <div className='flex items-center'>
+                      <ScaleIcon className='h-4 w-4 mr-2 text-gray-400 flex-shrink-0' />
+                      <span className='truncate'>{court.name}</span>
+                    </div>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </nav>
+    </StandardSidebar>
+  );
+}

--- a/src/pages/government/judicial/index.tsx
+++ b/src/pages/government/judicial/index.tsx
@@ -1,0 +1,152 @@
+import { ScaleIcon, ExternalLinkIcon, MapPinIcon } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import SEO from '../../../components/SEO';
+import { getJudicialSEOData } from '../../../utils/seo-data';
+import judicialData from '../../../data/directory/judicial.json';
+
+type JudicialCourt = (typeof judicialData)[number];
+
+export default function JudicialIndex() {
+  const { court: courtParam } = useParams();
+  const [selectedCourt, setSelectedCourt] = useState<JudicialCourt | null>(
+    null
+  );
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (courtParam) {
+      const court = judicialData.find(
+        c => c.slug === decodeURIComponent(courtParam)
+      );
+      if (court) {
+        setSelectedCourt(court);
+      }
+    } else if (judicialData.length > 0) {
+      setSelectedCourt(judicialData[0]);
+      navigate(
+        `/government/judicial/${encodeURIComponent(judicialData[0].slug)}`
+      );
+    } else {
+      setSelectedCourt(null);
+    }
+  }, [courtParam, navigate]);
+
+  const seoData = getJudicialSEOData(selectedCourt?.name);
+
+  if (!selectedCourt) {
+    return (
+      <>
+        <SEO
+          keywords={seoData.keywords}
+          canonical={seoData.canonical}
+          breadcrumbs={seoData.breadcrumbs}
+          jsonLd={seoData.jsonLd}
+        />
+        <div className='@container bg-white rounded-lg border p-8 text-center h-full flex flex-col items-center justify-center'>
+          <div className='mx-auto w-12 h-12 rounded-full bg-gray-50 flex items-center justify-center mb-4'>
+            <ScaleIcon className='h-6 w-6 text-gray-400' />
+          </div>
+          <h3 className='text-lg font-medium text-gray-900 mb-1'>
+            No court selected
+          </h3>
+          <p className='text-gray-800 max-w-md'>
+            Select a court from the list to view its details and justices.
+          </p>
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <SEO
+        keywords={seoData.keywords}
+        canonical={seoData.canonical}
+        breadcrumbs={seoData.breadcrumbs}
+        jsonLd={seoData.jsonLd}
+      />
+      <div className='@container space-y-6'>
+        {/* Court Header */}
+        <div className='flex flex-col space-y-2'>
+          <h1 className='text-3xl font-bold text-gray-900 mb-2'>
+            {selectedCourt.name}
+          </h1>
+          {selectedCourt.description && (
+            <p className='text-gray-800 text-sm'>{selectedCourt.description}</p>
+          )}
+          {selectedCourt.address && (
+            <p className='mt-2 text-gray-800 flex items-start text-sm'>
+              <MapPinIcon className='h-4 w-4 text-gray-400 mr-2 mt-0.5 flex-shrink-0' />
+              <span>{selectedCourt.address}</span>
+            </p>
+          )}
+          {selectedCourt.website && (
+            <div className='flex space-x-2 flex-row text-sm'>
+              <ExternalLinkIcon className='h-4 w-4 text-gray-400 mt-0.5 flex-shrink-0' />
+              <a
+                href={`https://${selectedCourt.website}`}
+                target='_blank'
+                rel='noopener noreferrer'
+                className='text-primary-600 hover:underline'
+              >
+                {selectedCourt.website}
+              </a>
+            </div>
+          )}
+        </div>
+
+        {/* Justices Table */}
+        {selectedCourt.officials && selectedCourt.officials.length > 0 && (
+          <div>
+            <h2 className='text-xl font-semibold text-gray-900 mb-4'>
+              Incumbent Justices{' '}
+              <span className='text-sm font-normal text-primary-600'>
+                ({selectedCourt.officials.length})
+              </span>
+            </h2>
+            <div className='overflow-x-auto rounded-lg border border-gray-200'>
+              <table className='min-w-full divide-y divide-gray-200 text-sm'>
+                <thead className='bg-gray-50'>
+                  <tr>
+                    <th className='px-4 py-3 text-left font-medium text-gray-700'>
+                      #
+                    </th>
+                    <th className='px-4 py-3 text-left font-medium text-gray-700'>
+                      Name
+                    </th>
+                    <th className='px-4 py-3 text-left font-medium text-gray-700'>
+                      Position
+                    </th>
+                    <th className='px-4 py-3 text-left font-medium text-gray-700'>
+                      Date of Appointment
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className='divide-y divide-gray-100 bg-white'>
+                  {selectedCourt.officials.map((justice, index) => (
+                    <tr
+                      key={index}
+                      className='hover:bg-gray-50 transition-colors'
+                    >
+                      <td className='px-4 py-3 text-gray-500'>{index + 1}</td>
+                      <td className='px-4 py-3 font-medium text-gray-900'>
+                        {justice.name}
+                      </td>
+                      <td className='px-4 py-3 text-gray-700'>
+                        {justice.role}
+                      </td>
+                      <td className='px-4 py-3 text-gray-500'>
+                        {justice.date_of_appointment || '—'}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/src/pages/government/judicial/layout.tsx
+++ b/src/pages/government/judicial/layout.tsx
@@ -1,0 +1,11 @@
+import { Outlet } from 'react-router-dom';
+import JudicialSidebar from './components/JudicialSidebar';
+import GovernmentPageContainer from '../GovernmentPageContainer';
+
+export default function JudicialPageLayout() {
+  return (
+    <GovernmentPageContainer sidebar={<JudicialSidebar />}>
+      <Outlet />
+    </GovernmentPageContainer>
+  );
+}

--- a/src/pages/government/layout.tsx
+++ b/src/pages/government/layout.tsx
@@ -7,6 +7,7 @@ import {
   GlobeIcon,
   BookOpenIcon,
   MapPinIcon,
+  ScaleIcon,
 } from 'lucide-react';
 import { cn } from '../../lib/utils';
 
@@ -63,6 +64,13 @@ export default function GovernmentLayout({ children }: GovernmentLayoutProps) {
         'Philippine embassies, consulates, and diplomatic missions around the world.',
       icon: <GlobeIcon className='h-4 w-4' />,
       path: '/government/diplomatic',
+    },
+    {
+      title: 'Judicial Branch',
+      description:
+        'The Supreme Court, Court of Appeals, and other courts that interpret and apply the law.',
+      icon: <ScaleIcon className='h-4 w-4' />,
+      path: '/government/judicial',
     },
   ];
 

--- a/src/utils/seo-data.ts
+++ b/src/utils/seo-data.ts
@@ -347,3 +347,51 @@ export function getLocalGovSEOData(regionName?: string): GovernmentSEOData {
     },
   };
 }
+export function getJudicialSEOData(courtName?: string): GovernmentSEOData {
+  const baseTitle = 'Judicial Branch';
+  const title = courtName ? `${courtName} - ${baseTitle}` : baseTitle;
+
+  return {
+    title,
+    description: courtName
+      ? `Information and incumbent justices of the ${courtName}. A directory of the Philippine Judicial Branch.`
+      : 'A directory of the Philippine Judicial Branch including the Supreme Court, Court of Appeals, and Sandiganbayan.',
+    keywords: [
+      ...baseKeywords,
+      'Judicial Branch',
+      'Supreme Court',
+      'Court of Appeals',
+      'Sandiganbayan',
+      'Incumbent Justices',
+      'Philippine Judiciary',
+      ...(courtName ? [courtName] : []),
+    ],
+    canonical: courtName
+      ? `/government/judicial/${encodeURIComponent(courtName)}`
+      : '/government/judicial',
+    breadcrumbs: [
+      { name: 'Home', url: '/' },
+      { name: 'Government', url: '/government' },
+      { name: 'Judicial Branch', url: '/government/judicial' },
+      ...(courtName
+        ? [
+            {
+              name: courtName,
+              url: `/government/judicial/${encodeURIComponent(courtName)}`,
+            },
+          ]
+        : []),
+    ],
+    jsonLd: {
+      '@context': 'https://schema.org',
+      '@type': 'GovernmentOrganization',
+      name: courtName || 'Philippine Judicial Branch',
+      url: `https://gov.ph/government/judicial${
+        courtName ? `/${encodeURIComponent(courtName)}` : ''
+      }`,
+      description: courtName
+        ? `${courtName} - Philippine Judicial Branch`
+        : 'A directory of the Philippine Judicial Branch',
+    },
+  };
+}

--- a/src/version.json
+++ b/src/version.json
@@ -1,3 +1,3 @@
 {
-  "head_commit": "25c765cd02a49f51b16ecbd89e83b9e94d6a1fa0"
+  "head_commit": "14d00fbafb75d9a7cdac6eb38b77266d1c636660"
 }


### PR DESCRIPTION
## Description
This PR adds a dedicated Judicial Branch subpage at `/government/judicial` to complete the government directory, as requested in issue #260. 

The new subpage follows the exact same component structure and layout template as the existing Constitutional and Legislative branch pages.

## Changes Made
- **Data:** Created `src/data/directory/judicial.json` containing the Supreme Court, Court of Appeals, and Sandiganbayan, along with incumbent justices.
- **Pages & Components:** 
  - Added `src/pages/government/judicial/layout.tsx` for the page layout.
  - Added `src/pages/government/judicial/index.tsx` for the main content and justices table.
  - Added `src/pages/government/judicial/components/JudicialSidebar.tsx` for court navigation.
- **Routing:** Registered the new routes in `src/App.tsx`.
- **Navigation:** 
  - Added a "Judicial Branch" card to the main government layout (`src/pages/government/layout.tsx`).
  - Added "Judicial" to the top navbar dropdown (`src/data/navigation.ts`).
- **SEO:** Added `getJudicialSEOData()` to `src/utils/seo-data.ts`.

Closes #260

## AI Disclosure
This contribution was developed with the assistance of an AI coding tool (Antigravity/Gemini).