### PR TITLE
fix(flood-control): localize data export alert messages

### DIFF
--- a/src/pages/flood-control-projects/contractors.tsx
+++ b/src/pages/flood-control-projects/contractors.tsx
@@ -10,6 +10,7 @@ import {
 import { instantMeiliSearch } from '@meilisearch/instant-meilisearch';
 import 'instantsearch.css/themes/satellite.css';
 import { exportMeilisearchData } from '../../lib/exportData';
+import { useTranslation } from 'react-i18next';
 import {
   DownloadIcon,
   ArrowUpDownIcon,
@@ -538,6 +539,7 @@ const ContractorItem: FC<ContractorItemProps> = ({
 
 // Main Contractors component
 const FloodControlProjectsContractors: FC = () => {
+  const { t } = useTranslation('flood-control-projects');
   const navigate = useNavigate();
 
   const [selectedContractor, setSelectedContractor] = useState('');
@@ -591,10 +593,10 @@ const FloodControlProjectsContractors: FC = () => {
           : 'flood-control-projects-contractors',
       });
       // Show success message
-      alert('Data exported successfully!');
+      alert(t('alerts.exportSuccess'));
     } catch (error) {
       console.error('Error exporting data:', error);
-      alert('Failed to export data. Please try again.');
+      alert(t('alerts.exportError'));
     } finally {
       // Reset loading state
       setIsExporting(false);

--- a/src/pages/flood-control-projects/contractors/[contractor-name].tsx
+++ b/src/pages/flood-control-projects/contractors/[contractor-name].tsx
@@ -5,6 +5,7 @@ import { InstantSearch, Configure, useHits } from 'react-instantsearch';
 import { instantMeiliSearch } from '@meilisearch/instant-meilisearch';
 import 'instantsearch.css/themes/satellite.css';
 import { exportMeilisearchData } from '../../../lib/exportData';
+import { useTranslation } from 'react-i18next';
 import {
   ChevronLeft,
   Download,
@@ -515,6 +516,7 @@ const initialCenter: LatLngExpression = [12.8797, 121.774];
 
 // Main Contractor Detail component
 const ContractorDetail: FC = () => {
+  const { t } = useTranslation('flood-control-projects');
   const { 'contractor-name': contractorSlug } = useParams<{
     'contractor-name': string;
   }>();
@@ -617,10 +619,10 @@ const ContractorDetail: FC = () => {
         filename: `flood-control-projects-${createSlug(contractor.value)}`,
       });
       // Show success message
-      alert('Data exported successfully!');
+      alert(t('alerts.exportSuccess'));
     } catch (error) {
       console.error('Error exporting data:', error);
-      alert('Failed to export data. Please try again.');
+      alert(t('alerts.exportError'));
     } finally {
       // Reset loading state
       setIsExporting(false);

--- a/src/pages/flood-control-projects/map.tsx
+++ b/src/pages/flood-control-projects/map.tsx
@@ -4,6 +4,7 @@ import { InstantSearch, Configure, useHits } from 'react-instantsearch';
 import { instantMeiliSearch } from '@meilisearch/instant-meilisearch';
 import 'instantsearch.css/themes/satellite.css';
 import { exportMeilisearchData } from '../../lib/exportData';
+import { useTranslation } from 'react-i18next';
 import { DownloadIcon, InfoIcon, ZoomInIcon, ZoomOutIcon } from 'lucide-react';
 import Button from '../../components/ui/Button';
 import { MapContainer, TileLayer, GeoJSON } from 'react-leaflet';
@@ -96,6 +97,7 @@ const meiliSearchInstance = instantMeiliSearch(
 const searchClient = meiliSearchInstance.searchClient as any;
 
 const FloodControlProjectsMap: FC = () => {
+  const { t } = useTranslation('flood-control-projects');
   // Loading state for export
   const [isExporting, setIsExporting] = useState<boolean>(false);
 
@@ -145,10 +147,10 @@ const FloodControlProjectsMap: FC = () => {
         filename: 'flood-control-projects-map',
       });
       // Show success message
-      alert('Data exported successfully!');
+      alert(t('alerts.exportSuccess'));
     } catch (error) {
       console.error('Error exporting data:', error);
-      alert('Failed to export data. Please try again.');
+      alert(t('alerts.exportError'));
     } finally {
       // Reset loading state
       setIsExporting(false);

--- a/src/pages/flood-control-projects/table.tsx
+++ b/src/pages/flood-control-projects/table.tsx
@@ -4,6 +4,7 @@ import { InstantSearch, Configure, useHits } from 'react-instantsearch';
 import { instantMeiliSearch } from '@meilisearch/instant-meilisearch';
 import 'instantsearch.css/themes/satellite.css';
 import { exportMeilisearchData } from '../../lib/exportData';
+import { useTranslation } from 'react-i18next';
 import {
   Filter,
   ChevronLeft,
@@ -611,6 +612,7 @@ const TableHits: FC<{ filters: FilterState; searchTerm: string }> = ({
 };
 
 const FloodControlProjectsTable: FC = () => {
+  const { t } = useTranslation('flood-control-projects');
   const [searchParams, setSearchParams] = useSearchParams();
 
   // State for filters and search
@@ -737,10 +739,10 @@ const FloodControlProjectsTable: FC = () => {
         filename: 'flood-control-projects-table',
       });
       // Show success message
-      alert('Data exported successfully!');
+      alert(t('alerts.exportSuccess'));
     } catch (error) {
       console.error('Error exporting data:', error);
-      alert('Failed to export data. Please try again.');
+      alert(t('alerts.exportError'));
     } finally {
       // Reset loading state
       setIsExporting(false);


### PR DESCRIPTION
## Summary

The "Export Data" buttons on the flood-control-projects pages show a
success/error alert when a download finishes. On four of these pages the
alert messages were hardcoded in English:

- `src/pages/flood-control-projects/table.tsx`
- `src/pages/flood-control-projects/map.tsx`
- `src/pages/flood-control-projects/contractors.tsx`
- `src/pages/flood-control-projects/contractors/[contractor-name].tsx`

So users browsing in a non-English locale (e.g. Filipino, Cebuano) still saw
English alerts — even though the translations already exist
(`alerts.exportSuccess` / `alerts.exportError` in
`public/locales/<lang>/flood-control-projects.json`) and are already used
correctly on the main page (`index.tsx`).

## Changes

- Add `useTranslation('flood-control-projects')` to the four affected components.
- Replace the hardcoded alert strings with the existing keys
  `t('alerts.exportSuccess')` / `t('alerts.exportError')`, matching the pattern
  already used in `index.tsx`.

No new translation keys were added — this only uses keys that already exist.

## Testing

- `npm run lint` — passes
- `npm run test:unit` — passes (4/4)
- `npm run build` (vite) — builds successfully
