### PR TITLE
fix(civic-assistant): correct 'Initializing' typo in loading message

### DIFF
--- a/src/components/ui/CivicAssistant.tsx
+++ b/src/components/ui/CivicAssistant.tsx
@@ -68,7 +68,7 @@ const CivicAssistant: React.FC = () => {
                 </div>
                 <div className='bg-gray-100 dark:bg-gray-800 p-3 rounded-2xl rounded-tl-none text-sm max-w-[85%] text-gray-700 dark:text-gray-300'>
                   {isInitializing
-                    ? 'Initialzing knowledge base...'
+                    ? 'Initializing knowledge base...'
                     : 'Hello! I can help you find government services. What are you looking for?'}
                 </div>
               </div>


### PR DESCRIPTION
## Summary

Fixes a small user-visible typo in the Civic Assistant widget. While the
knowledge base is loading, the assistant shows a status message that read
**"Initialzing knowledge base..."** — corrected to **"Initializing
knowledge base..."**.

The `CivicAssistant` component is mounted in `src/App.tsx`, so this text is
shown to real users.

## Changes

- `src/components/ui/CivicAssistant.tsx`: `Initialzing` → `Initializing`

## Testing

- `npm run lint` — passes
