### PR TITLE
feat(ui): update Discord links to use Discord icon matching Footer.tsx

### DIFF
--- a/src/components/home/JoinUsBanner.tsx
+++ b/src/components/home/JoinUsBanner.tsx
@@ -2,6 +2,7 @@ import { ArrowRightIcon, UsersIcon, ZapIcon } from 'lucide-react';
 import { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
+import { SiDiscord } from '@icons-pack/react-simple-icons';
 
 const JoinUsBanner: FC = () => {
   const { t } = useTranslation('common');
@@ -58,6 +59,7 @@ const JoinUsBanner: FC = () => {
               rel='noreferrer'
               className='inline-flex items-center justify-center px-6 py-3 border-2 border-white text-white font-semibold rounded-lg hover:bg-white hover:text-gray-900 transition-all'
             >
+              <SiDiscord className='h-5 w-5 mr-2' />
               {t('joinUs.joinDiscord')}
             </a>
           </div>

--- a/src/components/home/JoinUsStrip.tsx
+++ b/src/components/home/JoinUsStrip.tsx
@@ -1,7 +1,8 @@
 import { FC } from 'react';
-import { UsersIcon, ArrowRightIcon, ZapIcon } from 'lucide-react';
+import { UsersIcon, ArrowRightIcon } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { SiDiscord } from '@icons-pack/react-simple-icons';
 
 const JoinUsStrip: FC = () => {
   const { t } = useTranslation('common');
@@ -13,11 +14,8 @@ const JoinUsStrip: FC = () => {
       {/* Animated background elements */}
       <div className='absolute left-0 top-0 w-full h-full opacity-20'>
         <div className='flex items-center justify-around h-full animate-pulse'>
-          <ZapIcon className='h-4 w-4' />
           <UsersIcon className='h-4 w-4' />
-          <ZapIcon className='h-4 w-4' />
           <UsersIcon className='h-4 w-4' />
-          <ZapIcon className='h-4 w-4' />
         </div>
       </div>
 
@@ -49,8 +47,9 @@ const JoinUsStrip: FC = () => {
               href='https://discord.gg/mHtThpN8bT'
               target='_blank'
               rel='noreferrer'
-              className='text-xs text-yellow-200 hover:text-yellow-100 underline transition-colors'
+              className='inline-flex items-center gap-1.5 text-xs text-yellow-200 hover:text-yellow-100 underline transition-colors'
             >
+              <SiDiscord className='h-3.5 w-3.5' />
               {t('joinUs.discord')}
             </a>
           </div>

--- a/src/components/home/JoinUsStrip.tsx
+++ b/src/components/home/JoinUsStrip.tsx
@@ -1,5 +1,5 @@
 import { FC } from 'react';
-import { UsersIcon, ArrowRightIcon } from 'lucide-react';
+import { UsersIcon, ArrowRightIcon, ZapIcon } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { SiDiscord } from '@icons-pack/react-simple-icons';
@@ -14,8 +14,11 @@ const JoinUsStrip: FC = () => {
       {/* Animated background elements */}
       <div className='absolute left-0 top-0 w-full h-full opacity-20'>
         <div className='flex items-center justify-around h-full animate-pulse'>
+          <ZapIcon className='h-4 w-4' />
           <UsersIcon className='h-4 w-4' />
+          <ZapIcon className='h-4 w-4' />
           <UsersIcon className='h-4 w-4' />
+          <ZapIcon className='h-4 w-4' />
         </div>
       </div>
 

--- a/src/pages/ContactUs.tsx
+++ b/src/pages/ContactUs.tsx
@@ -1,6 +1,5 @@
 import {
   MailIcon,
-  MessageCircleIcon,
   UsersIcon,
   GlobeIcon,
   ArrowRightIcon,
@@ -8,6 +7,7 @@ import {
   ChevronDownIcon,
   ChevronUpIcon,
 } from 'lucide-react';
+import { SiDiscord } from '@icons-pack/react-simple-icons';
 import { FC, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { Link } from 'react-router-dom';
@@ -24,7 +24,7 @@ const ContactUs: FC = () => {
       color: 'bg-blue-100 text-blue-600',
     },
     {
-      icon: <MessageCircleIcon className='h-8 w-8' />,
+      icon: <SiDiscord className='h-8 w-8' />,
       title: 'Discord Community',
       description:
         'Join our volunteer community for real-time discussions and support',

--- a/src/pages/JoinUs.tsx
+++ b/src/pages/JoinUs.tsx
@@ -5,7 +5,6 @@ import {
   GlobeIcon,
   HeartIcon,
   LightbulbIcon,
-  MessageCircleIcon,
   RocketIcon,
   ServerIcon,
   StarIcon,
@@ -13,6 +12,7 @@ import {
   UsersIcon,
   ZapIcon,
 } from 'lucide-react';
+import { SiDiscord } from '@icons-pack/react-simple-icons';
 import { FC } from 'react';
 import { Helmet } from 'react-helmet-async';
 
@@ -62,7 +62,7 @@ const JoinUs: FC = () => {
                 rel='noreferrer'
                 className='inline-flex items-center justify-center px-8 py-4 bg-yellow-400 text-gray-900 font-bold rounded-lg hover:bg-yellow-300 transition-all transform hover:scale-105 shadow-lg'
               >
-                <MessageCircleIcon className='h-5 w-5 mr-2' />
+                <SiDiscord className='h-5 w-5 mr-2' />
                 Join Our Discord
               </a>
               <a
@@ -268,7 +268,7 @@ const JoinUs: FC = () => {
                 rel='noreferrer'
                 className='inline-flex items-center justify-center px-8 py-4 bg-yellow-400 text-gray-900 font-bold rounded-lg hover:bg-yellow-300 transition-all transform hover:scale-105 shadow-lg text-lg'
               >
-                <MessageCircleIcon className='h-6 w-6 mr-3' />
+                <SiDiscord className='h-6 w-6 mr-3' />
                 Join Our Discord Community
               </a>
 


### PR DESCRIPTION
# What type of PR is this?

- [ ] Bug
- [x] Change
- [x] Feature
- [ ] Miscellaneous

---

## What you changed and why?

- Updated Discord links across pages to use the Discord icon matching `Footer.tsx` instead of `MessageCircleIcon`.
- Added the Discord icon to the left of the Discord link in `JoinUsStrip.tsx`.

---

## Please specify which issue this PR Resolves (if applicable)

N/A

---

## Checklist

- [x] I have performed a self-review of my own code.
- [x] These changes are now ready for review, or will be marked as draft.
- [ ] This contribution was assisted by an AI agent. (if yes, please specify what agent is used under notes)

---

## Notes

<img width="1002" height="501" alt="image" src="https://github.com/user-attachments/assets/846caaac-d8de-4938-88d6-86987085537e" />
<img width="1044" height="511" alt="image" src="https://github.com/user-attachments/assets/787c46db-20b0-4aeb-9644-85b2533a66ec" />