### PR TITLE
Fix broken passport and travel service url

### DIFF
--- a/src/data/services/passport-travel.json
+++ b/src/data/services/passport-travel.json
@@ -1,7 +1,7 @@
 [
   {
     "service": "Apply Travel Clearance for Minors",
-    "url": "https://ncr.dswd.gov.ph/faqs/travel-clearance-for-minors/",
+    "url": "https://transparency.dswd.gov.ph/faqs/travel-clearance-for-minors/",
     "id": "167d391d-4185-4fcc-8aec-045df84f4f40",
     "slug": "apply-travel-clearance-for-minors",
     "published": true,


### PR DESCRIPTION
# What type of PR is this?

- [x] Bug
- [ ] Change
- [ ] Feature
- [ ] Miscellaneous

---

## What you changed and why?

- Inspected the Passport and Travel service links.
- Updated broken or outdated official URLs in `src/data/passport-travel.json`.
- Replaced links that returned 404 errors with the current official government pages.

-

---

## Please specify which issue this PR Resolves (if applicable)

This PR closes #685

---

## Checklist

- [x] I have performed a self-review of my own code.
- [x] These changes are now ready for review, or will be marked as draft.
- [ ] This contribution was assisted by an AI agent. (if yes, please specify what agent is used under notes)

---

## Notes

<!-- Add video demos/screenshots, etc, other notes -->

- ...

---
