### PR TITLE
fix(scripts): handle missing git gracefully in Docker builds

### DIFF
--- a/scripts/write-ver-to-json.ts
+++ b/scripts/write-ver-to-json.ts
@@ -15,10 +15,15 @@ const __dirname = path.dirname(__filename);
 const versionPath = path.join(__dirname, '..', 'src', 'version.json');
 
 // Get current commit hash
-const hash =
-  process.env.HEAD_COMMIT_HASH ||
-  execSync('git rev-parse HEAD').toString().trim() ||
-  'unknown';
+let hash = process.env.HEAD_COMMIT_HASH || 'unknown';
+if (hash === 'unknown') {
+  try {
+    const result = execSync('git rev-parse HEAD').toString().trim();
+    if (result) hash = result;
+  } catch {
+    // git not available or not in a git repository (e.g. Docker build)
+  }
+}
 
 // Prepare version object
 const versionData = { head_commit: hash };

--- a/scripts/write-ver-to-json.ts
+++ b/scripts/write-ver-to-json.ts
@@ -21,7 +21,7 @@ if (hash === 'unknown') {
     const result = execSync('git rev-parse HEAD').toString().trim();
     if (result) hash = result;
   } catch {
-    // git not available or not in a git repository (e.g. Docker build)
+    console.warn('⚠️ Could not determine Git commit hash. Using "unknown".');
   }
 }
 


### PR DESCRIPTION
## Summary

Wraps `execSync('git rev-parse HEAD')` in a try-catch in `scripts/write-ver-to-json.ts` so the Docker build succeeds when git is not installed in the container.

## Problem

Running `docker compose up` fails with `/bin/sh: git: not found` because:
1. The `node:22-alpine` image doesn't include git
2. `docker-compose.yml` doesn't pass the `HEAD_COMMIT_HASH` build arg
3. `write-ver-to-json.ts` calls `execSync('git rev-parse HEAD')` as a fallback, which throws

## Fix

The script now gracefully falls back to `"unknown"` when neither `HEAD_COMMIT_HASH` nor git is available, instead of crashing the build.

## Validation

- `docker compose build` — exit 0
- `docker compose up` — Vite dev server starts on :5173
- `tsc` type-check passed during build
- Existing behavior preserved when git IS available or `HEAD_COMMIT_HASH` is set

Closes #673