### PR TITLE
fix: gracefully handle missing git binary in write-ver-to-json script

### DIFF
--- a/scripts/write-ver-to-json.ts
+++ b/scripts/write-ver-to-json.ts
@@ -15,10 +15,15 @@ const __dirname = path.dirname(__filename);
 const versionPath = path.join(__dirname, '..', 'src', 'version.json');
 
 // Get current commit hash
-const hash =
-  process.env.HEAD_COMMIT_HASH ||
-  execSync('git rev-parse HEAD').toString().trim() ||
-  'unknown';
+function getGitCommitHash(): string {
+  try {
+    return execSync('git rev-parse HEAD').toString().trim();
+  } catch {
+    return 'unknown';
+  }
+}
+
+const hash = process.env.HEAD_COMMIT_HASH || getGitCommitHash();
 
 // Prepare version object
 const versionData = { head_commit: hash };


### PR DESCRIPTION
Fixes #673

## Root Cause
`write-ver-to-json.ts` falls back to `execSync('git rev-parse HEAD')` when 
the `HEAD_COMMIT_HASH` build-arg isn't set (which is the default in 
`docker compose up`). This crashes with `/bin/sh: git: not found` on the 
git-less `node:22-alpine` base image used in the Dockerfile.

## Fix
Wrapped the git command in a try-catch, falling back to `'unknown'` 
instead of crashing the build.

## Testing
- Reproduced the exact reported error by removing `git` from PATH locally 
  — confirmed same error message `/bin/sh: git: not found`
- With fix applied: build completes successfully, `version.json` gets 
  `"head_commit": "unknown"` when git is unavailable, and the real commit 
  hash when git is available (no regression for normal local dev)
- Verified `docker compose up --build` now completes without error