### PR TITLE
chore: update Senators roles and local numbers - 20th Congress

### DIFF
--- a/src/data/directory/legislative.json
+++ b/src/data/directory/legislative.json
@@ -298,12 +298,12 @@
       {
         "role": "Senate Secretary",
         "name": "RENATO N. BANTUG JR.",
-        "contact": "loc. 6122; 8552-6735"
+        "contact": "loc. 6122"
       },
       {
         "role": "Sergeant-at-Arms",
-        "name": "MA.O APLASCA",
-        "contact": "loc. 1406 to 1407; 8552-6867"
+        "name": "ALFRED S. CORPUS",
+        "contact": "loc. 1407"
       },
       {
         "role": "Deputy Secretary for Legislation",
@@ -329,13 +329,13 @@
         "role": "Director General",
         "name": "EIREEN R. PALANCA",
         "office": "Legislative Budget Research and Monitoring Office",
-        "contact": "loc. 2136; 8552-6812,8552-6887"
+        "contact": "loc. 2138; 8552-6811, 8552-6887"
       },
       {
         "role": "Director General",
         "name": "RODELIO T. DASCIL",
         "office": "Senate Tax Study and Research Office",
-        "contact": "loc. 5507, 5508; 8834-6590"
+        "contact": "loc. 5507; 8552-6850"
       },
       {
         "role": "Director General",
@@ -353,7 +353,7 @@
         "role": "Director General",
         "name": "LINO S. ONG",
         "office": "Senate Public Assistance Office",
-        "contact": "loc.. 1116, 1114; 8552-6708; 8552-6704"
+        "contact": "loc. 1113, 1114; 8552-6858"
       },
       {
         "role": "Director General",

--- a/src/data/directory/legislative.json
+++ b/src/data/directory/legislative.json
@@ -9,13 +9,13 @@
     "officials": [
       {
         "role": "Senate President",
-        "name": "VICENTE C. SOTTO III",
-        "contact": "local nos. 6501-6504"
+        "name": "SHERWIN GATCHALIAN",
+        "contact": "local nos. 5710, 8622"
       },
       {
         "role": "Senate President Pro Tempore",
-        "name": "PANFILO M. LACSON",
-        "contact": "local nos. 5790-5792 / 8617"
+        "name": "VICENTE C. SOTTO III",
+        "contact": "local no. 6501"
       },
       {
         "role": "Senate Majority Leader",
@@ -55,12 +55,7 @@
       {
         "role": "Senator",
         "name": "JINGGOY EJERCITO ESTRADA",
-        "contact": "local nos. 6811, 6826"
-      },
-      {
-        "role": "Senator",
-        "name": "SHERWIN GATCHALIAN",
-        "contact": "local nos. 5710, 8622"
+        "contact": "local nos. 6810, 6811, and 6826"
       },
       {
         "role": "Senator",
@@ -71,6 +66,11 @@
         "role": "Senator",
         "name": "RISA HONTIVEROS",
         "contact": "local nos. 8603 / 8529 / 5781"
+      },
+      {
+        "role": "Senator",
+        "name": "PANFILO M. LACSON",
+        "contact": "local nos. 5671 to 5674"
       },
       {
         "role": "Senator",


### PR DESCRIPTION
# What type of PR is this?

- [ ] Bug
- [x] Change
- [ ] Feature
- [ ] Miscellaneous

---

## What you changed and why?

- Updated Senators roles and local numbers for the 20th Congress in `src/data/directory/legislative.json` due to it being outdated. ([Source](https://senate.gov.ph/senators/20-congress-senators))

---

## Please specify which issue this PR Resolves (if applicable)

This PR partially resolves #700 [Senate of the Philippines (20th Congress) **only**.]

---

## Checklist

- [x] I have performed a self-review of my own code.
- [x] These changes are now ready for review, or will be marked as draft.
- [ ] This contribution was assisted by an AI agent. (if yes, please specify what agent is used under notes)

---

## Notes
- Also updated the Senate Secretariat (and local numbers). ([Source](https://senate.gov.ph/secretariat/officers-of-the-secretariat))
- No Senate Committees chairperson list yet in the Senate website at the moment.
- Latest info as of July 29, 2026. 