### PR TITLE
fix(seo): use active locale for DC.language metadata

### DIFF
--- a/src/components/SEO.tsx
+++ b/src/components/SEO.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import { Helmet } from 'react-helmet-async';
 import routeMeta from '../data/seo-metadata.json';
 import {
@@ -33,7 +34,9 @@ export default function SEO({
   breadcrumbs,
 }: SEOProps = {}) {
   const location = useLocation();
+  const { i18n } = useTranslation();
   const [, forceUpdate] = useState({});
+  const dcLanguage = i18n.resolvedLanguage || i18n.language || 'en';
 
   const routeMetaMap = routeMeta as Record<string, unknown>;
 
@@ -158,7 +161,7 @@ export default function SEO({
     : null;
 
   return (
-    <Helmet key={`${location.pathname}${location.search}`}>
+    <Helmet key={`${location.pathname}${location.search}-${dcLanguage}`}>
       {/* Basic Meta Tags */}
       <title>{fullTitle}</title>
       <meta name='description' content={finalDescription} />
@@ -189,7 +192,7 @@ export default function SEO({
       {/* Government Specific Meta Tags */}
       <meta name='geo.country' content='PH' />
       <meta name='geo.region' content='PH' />
-      <meta name='DC.language' content='en' />
+      <meta name='DC.language' content={dcLanguage} />
       <meta name='DC.creator' content='BetterGov.ph' />
       <meta name='DC.publisher' content='BetterGov.ph' />
 

--- a/src/components/__tests__/SEO.test.tsx
+++ b/src/components/__tests__/SEO.test.tsx
@@ -1,0 +1,103 @@
+import { render, waitFor } from '@testing-library/react';
+import { HelmetProvider } from 'react-helmet-async';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import SEO from '../SEO';
+
+const mockUseTranslation = vi.fn();
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => mockUseTranslation(),
+}));
+
+describe('SEO', () => {
+  beforeEach(() => {
+    document.head.innerHTML = '';
+    mockUseTranslation.mockReturnValue({
+      i18n: { language: 'en', resolvedLanguage: 'en' },
+    });
+  });
+
+  it('sets DC.language from the active i18n locale', async () => {
+    mockUseTranslation.mockReturnValue({
+      i18n: { language: 'fil', resolvedLanguage: 'fil' },
+    });
+
+    render(
+      <HelmetProvider>
+        <MemoryRouter initialEntries={['/']}>
+          <SEO />
+        </MemoryRouter>
+      </HelmetProvider>
+    );
+
+    await waitFor(() => {
+      expect(
+        document
+          .querySelector('meta[name="DC.language"]')
+          ?.getAttribute('content')
+      ).toBe('fil');
+    });
+  });
+
+  it('updates DC.language when the active locale changes', async () => {
+    const i18n = { language: 'en', resolvedLanguage: 'en' };
+    mockUseTranslation.mockReturnValue({ i18n });
+
+    const { rerender } = render(
+      <HelmetProvider>
+        <MemoryRouter initialEntries={['/']}>
+          <SEO />
+        </MemoryRouter>
+      </HelmetProvider>
+    );
+
+    await waitFor(() => {
+      expect(
+        document
+          .querySelector('meta[name="DC.language"]')
+          ?.getAttribute('content')
+      ).toBe('en');
+    });
+
+    i18n.language = 'fil';
+    i18n.resolvedLanguage = 'fil';
+    rerender(
+      <HelmetProvider>
+        <MemoryRouter initialEntries={['/']}>
+          <SEO />
+        </MemoryRouter>
+      </HelmetProvider>
+    );
+
+    await waitFor(() => {
+      expect(
+        document
+          .querySelector('meta[name="DC.language"]')
+          ?.getAttribute('content')
+      ).toBe('fil');
+    });
+  });
+
+  it('falls back to en when i18n language is unavailable', async () => {
+    mockUseTranslation.mockReturnValue({
+      i18n: { language: '', resolvedLanguage: '' },
+    });
+
+    render(
+      <HelmetProvider>
+        <MemoryRouter initialEntries={['/']}>
+          <SEO />
+        </MemoryRouter>
+      </HelmetProvider>
+    );
+
+    await waitFor(() => {
+      expect(
+        document
+          .querySelector('meta[name="DC.language"]')
+          ?.getAttribute('content')
+      ).toBe('en');
+    });
+  });
+});


### PR DESCRIPTION
# What type of PR is this?

- [x] Bug
- [ ] Change
- [ ] Feature
- [ ] Miscellaneous

---

## What you changed and why?

- Replace the hardcoded `DC.language` metadata value with the active i18next locale.
- Refresh Helmet metadata when the locale changes.
- Add unit coverage for initial locale, locale changes, and the English fallback.

---

## Please specify which issue this PR Resolves (if applicable)

This PR closes #701

---

## Checklist

- [x] I have performed a self-review of my own code.
- [x] These changes are now ready for review, or will be marked as draft.
- [x] This contribution was assisted by an AI agent. (if yes, please specify what agent is used under notes)

---

## Notes

- Tests: `npm run test:unit`
- Lint: `npm run lint`
- Formatting: Prettier check passed
- No screenshot or recording is needed because this changes document metadata.

---

## AI Disclosure

- This contribution was developed with the assistance of an AI coding tool: OpenCode.
