### PR TITLE
ci: automate service link checks bi-monthly

### DIFF
--- a/.github/workflows/check-service-links.yml
+++ b/.github/workflows/check-service-links.yml
@@ -1,0 +1,194 @@
+name: Check Service Links
+
+on:
+  schedule:
+    - cron: '17 3 1 */2 *'
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: service-link-checks
+  cancel-in-progress: false
+
+jobs:
+  check-service-links:
+    name: Check service links
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Check service links
+        id: lychee
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
+        with:
+          args: "'src/data/services/*.json'"
+          checkbox: false
+          fail: false
+          failIfEmpty: true
+          format: json
+          jobSummary: false
+          lycheeVersion: v0.24.2
+          output: lychee/service-links.json
+          token: ''
+
+      - name: Classify service link results
+        id: classify
+        if: ${{ always() }}
+        continue-on-error: true
+        run: |
+          node scripts/report-service-links.js \
+            lychee/service-links.json \
+            lychee/service-links.md
+
+      - name: Update service link issue
+        if: ${{ always() && github.repository == 'bettergovph/bettergov' }}
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          CLASSIFY_OUTCOME: ${{ steps.classify.outcome }}
+          HARD_FAILURE_COUNT: ${{ steps.classify.outputs.hard_failure_count }}
+          MANUAL_REVIEW_COUNT: ${{ steps.classify.outputs.manual_review_count }}
+          LYCHEE_EXIT_CODE: ${{ steps.lychee.outputs.exit_code }}
+          LYCHEE_OUTCOME: ${{ steps.lychee.outcome }}
+          REPORT_PATH: lychee/service-links.md
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+
+            const title = '[Automated] Service link check report';
+            const labels = ['ci', 'needs-content-review', 'outdated-info'];
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              ...context.repo,
+              labels: 'ci',
+              state: 'open',
+              per_page: 100,
+            });
+            const existingIssue = issues.find(
+              (issue) => !issue.pull_request && issue.title === title,
+            );
+
+            const parseCount = (value) => /^\d+$/.test(value ?? '') ? Number(value) : null;
+            const hardFailureCount = parseCount(process.env.HARD_FAILURE_COUNT);
+            const manualReviewCount = parseCount(process.env.MANUAL_REVIEW_COUNT);
+            const lycheeCompleted = ['0', '2'].includes(process.env.LYCHEE_EXIT_CODE);
+            const classificationCompleted =
+              hardFailureCount !== null && manualReviewCount !== null;
+            const infrastructureFailure =
+              process.env.LYCHEE_OUTCOME !== 'success' ||
+              !lycheeCompleted ||
+              !classificationCompleted ||
+              (process.env.CLASSIFY_OUTCOME !== 'success' && hardFailureCount === 0);
+            const checkPassed =
+              !infrastructureFailure &&
+              hardFailureCount === 0 &&
+              manualReviewCount === 0;
+
+            if (checkPassed) {
+              if (existingIssue) {
+                await github.rest.issues.createComment({
+                  ...context.repo,
+                  issue_number: existingIssue.number,
+                  body: `No hard failures or manual-review items were found in [this workflow run](${runUrl}). Closing this automated report.`,
+                });
+                await github.rest.issues.update({
+                  ...context.repo,
+                  issue_number: existingIssue.number,
+                  state: 'closed',
+                  state_reason: 'completed',
+                });
+              }
+              return;
+            }
+
+            const report = fs.existsSync(process.env.REPORT_PATH)
+              ? fs.readFileSync(process.env.REPORT_PATH, 'utf8')
+              : 'Lychee did not produce a report. Inspect the workflow logs for an infrastructure or configuration error.';
+            const maxReportLength = 55000;
+            const trimmedReport = report.length > maxReportLength
+              ? `${report.slice(0, maxReportLength)}\n\n_Report truncated. See the workflow run for complete output._`
+              : report;
+            const body = [
+              infrastructureFailure
+                ? 'The automated service link check could not complete.'
+                : 'The automated service link check found links that need attention.',
+              '',
+              `- Workflow run: ${runUrl}`,
+              '- Source: `src/data/services/*.json`',
+              '- Parent task: #676',
+              `- Hard failures: ${hardFailureCount ?? 'unknown'}`,
+              `- Needs manual review: ${manualReviewCount ?? 'unknown'}`,
+              '',
+              'Hard failures fail the workflow. Manual-review items open this issue without failing the workflow. Automation-limited observations are informational.',
+              '',
+              trimmedReport,
+            ].join('\n');
+
+            if (existingIssue) {
+              await github.rest.issues.update({
+                ...context.repo,
+                issue_number: existingIssue.number,
+                body,
+                labels,
+              });
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: existingIssue.number,
+                body: `Report updated from [this workflow run](${runUrl}).`,
+              });
+              return;
+            }
+
+            await github.rest.issues.create({
+              ...context.repo,
+              title,
+              body,
+              labels,
+            });
+
+      - name: Fail on hard service link errors
+        if: ${{ always() }}
+        env:
+          CLASSIFY_OUTCOME: ${{ steps.classify.outcome }}
+          HARD_FAILURE_COUNT: ${{ steps.classify.outputs.hard_failure_count }}
+          LYCHEE_EXIT_CODE: ${{ steps.lychee.outputs.exit_code }}
+          LYCHEE_OUTCOME: ${{ steps.lychee.outcome }}
+        run: |
+          if [[ "$LYCHEE_OUTCOME" != 'success' ]]; then
+            echo 'Lychee did not complete successfully.'
+            exit 1
+          fi
+
+          if [[ "$LYCHEE_EXIT_CODE" != '0' && "$LYCHEE_EXIT_CODE" != '2' ]]; then
+            echo "Lychee exited unexpectedly with code: ${LYCHEE_EXIT_CODE:-unknown}"
+            exit 1
+          fi
+
+          if [[ ! "$HARD_FAILURE_COUNT" =~ ^[0-9]+$ ]]; then
+            echo 'The service link report did not provide a hard-failure count.'
+            exit 1
+          fi
+
+          if [[ "$CLASSIFY_OUTCOME" != 'success' && "$HARD_FAILURE_COUNT" == '0' ]]; then
+            echo 'The service link report could not be classified.'
+            exit 1
+          fi
+
+          if (( HARD_FAILURE_COUNT > 0 )); then
+            echo "Found $HARD_FAILURE_COUNT hard service link failure(s)."
+            exit 1
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -224,6 +224,18 @@ Schema validation runs automatically in CI/CD when changes are made to:
 - Schema files (`src/data/**/schema/*.json`)
 - The validation script (`scripts/validate-json-schema.js`)
 
+## Service Link Checks
+
+Government service URLs in `src/data/services/*.json` are checked every two months with [Lychee](https://lychee.cli.rs/). Install Lychee v0.24.2, then generate and classify the results locally:
+
+```sh
+lychee --config lychee.toml 'src/data/services/*.json'
+```
+
+Lychee may exit with an error for results that the workflow does not treat as hard failures. The report groups results into three levels: `404`, `410`, and DNS-resolution failures fail the workflow; connection failures and unknown errors open an issue for manual review without failing the workflow; and access restrictions, TLS compatibility errors, timeouts, connection resets, malformed responses, and redirects are informational because automated requests can behave differently from a browser.
+
+A successful HTTP response only confirms that the page is reachable; verify manually that it still describes the listed service.
+
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
 <!-- This can be added later -->

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,19 @@
+verbose = "info"
+no_progress = true
+
+max_redirects = 10
+max_retries = 3
+max_concurrency = 16
+host_concurrency = 1
+host_request_interval = "1s"
+
+timeout = 45
+retry_wait_time = 2
+method = "get"
+user_agent = "Mozilla/5.0 (compatible; BetterGov service link checker/1.0; +https://github.com/bettergovph/bettergov)"
+
+extensions = ["json"]
+scheme = ["http", "https"]
+exclude_all_private = true
+insecure = false
+accept_timeouts = false

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint . --report-unused-disable-directives --max-warnings 0",
     "format": "prettier --write .",
     "test:unit": "vitest run",
+    "test:service-links": "node --test scripts/report-service-links.tests.js",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",

--- a/scripts/report-service-links.js
+++ b/scripts/report-service-links.js
@@ -1,0 +1,205 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HARD_STATUS_CODES = new Set([404, 410]);
+const ACCESS_STATUS_CODES = new Set([401, 403, 429]);
+const DNS_ERROR_PATTERN =
+  /dns error|failed to lookup address|name or service not known|no records found|nodename nor servname/i;
+const AUTOMATION_LIMIT_PATTERN =
+  /certificate|\btls\b|\bssl\b|handshake|connection (?:reset|aborted)|invalid http response|incomplete message|timed? out|timeout/i;
+
+function flattenResultMap(resultMap = {}) {
+  return Object.entries(resultMap).flatMap(([source, results]) =>
+    results.map(result => ({ ...result, source }))
+  );
+}
+
+function locationKey(source, url) {
+  return `${source}\0${url}`;
+}
+
+export function classifyResults(results) {
+  const errors = flattenResultMap(results.error_map);
+  const timeouts = flattenResultMap(results.timeout_map);
+  const successes = flattenResultMap(results.success_map);
+  const locations = new Map(
+    [...successes, ...errors, ...timeouts].map(result => [
+      locationKey(result.source, result.url),
+      result.span,
+    ])
+  );
+
+  const hardFailures = errors.filter(result => {
+    const code = result.status?.code;
+    const description = `${result.status?.text ?? ''} ${result.status?.details ?? ''}`;
+    return HARD_STATUS_CODES.has(code) || DNS_ERROR_PATTERN.test(description);
+  });
+  const remainingErrors = errors.filter(
+    result => !hardFailures.includes(result)
+  );
+  const automationWarnings = [
+    ...remainingErrors.filter(result => {
+      const description = `${result.status?.text ?? ''} ${result.status?.details ?? ''}`;
+      return (
+        ACCESS_STATUS_CODES.has(result.status?.code) ||
+        AUTOMATION_LIMIT_PATTERN.test(description)
+      );
+    }),
+    ...timeouts,
+  ];
+  const manualReview = remainingErrors.filter(
+    result => !automationWarnings.includes(result)
+  );
+  const redirectWarnings = Object.entries(results.redirect_map ?? {}).flatMap(
+    ([source, redirects]) =>
+      redirects.map(redirect => ({
+        ...redirect,
+        source,
+        span: locations.get(locationKey(source, redirect.origin)),
+      }))
+  );
+
+  return {
+    summary: {
+      total: results.total ?? 0,
+      unique: results.unique ?? 0,
+      successful: results.successful ?? 0,
+    },
+    hardFailures,
+    manualReview,
+    automationWarnings,
+    redirectWarnings,
+  };
+}
+
+function formatLocation(result) {
+  const line = result.span?.line;
+  const label = line ? `${result.source}:${line}` : result.source;
+  const repository = process.env.GITHUB_REPOSITORY;
+  const revision = process.env.GITHUB_SHA;
+
+  if (!repository || !revision) {
+    return `\`${label}\``;
+  }
+
+  const serverUrl = process.env.GITHUB_SERVER_URL ?? 'https://github.com';
+  const lineAnchor = line ? `#L${line}` : '';
+  return `[${label}](${serverUrl}/${repository}/blob/${revision}/${result.source}${lineAnchor})`;
+}
+
+function formatResult(result, checkbox = false) {
+  const marker = checkbox ? '- [ ]' : '-';
+  const status =
+    result.status?.text ?? result.status?.details ?? 'Unknown error';
+  return `${marker} <${result.url}> | ${status} | ${formatLocation(result)}`;
+}
+
+function formatRedirect(result) {
+  const chain = result.redirects
+    .map(redirect => `[${redirect.code}] <${redirect.url}>`)
+    .join(' -> ');
+  return `- <${result.origin}> -> ${chain} | ${formatLocation(result)}`;
+}
+
+function formatSection(title, description, entries, formatter) {
+  const lines = [`## ${title}`, '', description, ''];
+  if (entries.length === 0) {
+    lines.push('None.');
+  } else {
+    lines.push(...entries.map(formatter));
+  }
+  return lines.join('\n');
+}
+
+export function createReport(classification) {
+  const {
+    summary,
+    hardFailures,
+    manualReview,
+    automationWarnings,
+    redirectWarnings,
+  } = classification;
+  const informationalCount =
+    automationWarnings.length + redirectWarnings.length;
+
+  return [
+    '# Service Link Check',
+    '',
+    '| Result | Count |',
+    '| --- | ---: |',
+    `| Total links | ${summary.total} |`,
+    `| Unique links | ${summary.unique} |`,
+    `| Successful checks | ${summary.successful} |`,
+    `| Hard failures | ${hardFailures.length} |`,
+    `| Needs manual review | ${manualReview.length} |`,
+    `| Informational observations | ${informationalCount} |`,
+    '',
+    formatSection(
+      `Hard Failures (${hardFailures.length})`,
+      'These responses strongly indicate dead links and fail the workflow.',
+      hardFailures,
+      result => formatResult(result, true)
+    ),
+    '',
+    formatSection(
+      `Needs Manual Review (${manualReview.length})`,
+      'These failures are inconclusive but may indicate broken links. They open an issue without failing the workflow.',
+      manualReview,
+      result => formatResult(result, true)
+    ),
+    '',
+    formatSection(
+      `Automation-Limited Observations (${automationWarnings.length})`,
+      'Access restrictions, TLS compatibility errors, timeouts, connection resets, and malformed responses are informational and require no immediate action.',
+      automationWarnings,
+      result => formatResult(result)
+    ),
+    '',
+    formatSection(
+      `Redirects (${redirectWarnings.length})`,
+      'Redirect destinations are recorded for reference and require no immediate action.',
+      redirectWarnings,
+      result => formatRedirect(result)
+    ),
+    '',
+    'Hard failures fail the workflow. Manual-review items open an issue without failing it. Informational observations require no immediate action.',
+    '',
+  ].join('\n');
+}
+
+function main() {
+  const [, , inputPath, outputPath] = process.argv;
+  const input = !inputPath || inputPath === '-' ? 0 : inputPath;
+  const results = JSON.parse(fs.readFileSync(input, 'utf8'));
+  const classification = classifyResults(results);
+  const report = createReport(classification);
+
+  if (outputPath && outputPath !== '-') {
+    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+    fs.writeFileSync(outputPath, report);
+  }
+  process.stdout.write(report);
+
+  if (process.env.GITHUB_OUTPUT) {
+    fs.appendFileSync(
+      process.env.GITHUB_OUTPUT,
+      `hard_failure_count=${classification.hardFailures.length}\nmanual_review_count=${classification.manualReview.length}\n`
+    );
+  }
+
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, report);
+  }
+
+  if (classification.hardFailures.length > 0) {
+    process.exitCode = 2;
+  }
+}
+
+if (
+  process.argv[1] &&
+  fileURLToPath(import.meta.url) === path.resolve(process.argv[1])
+) {
+  main();
+}

--- a/scripts/report-service-links.tests.js
+++ b/scripts/report-service-links.tests.js
@@ -1,0 +1,171 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+import { classifyResults, createReport } from './report-service-links.js';
+
+const source = 'src/data/services/example.json';
+
+function result(url, status, line) {
+  return { url, status, span: { line, column: 13 } };
+}
+
+test('classifies only strong dead-link signals as hard failures', () => {
+  const classification = classifyResults({
+    total: 12,
+    unique: 12,
+    successful: 1,
+    success_map: {
+      [source]: [
+        result(
+          'https://example.com/redirect',
+          { code: 200, text: '200 OK' },
+          1
+        ),
+      ],
+    },
+    error_map: {
+      [source]: [
+        result(
+          'https://example.com/missing',
+          { code: 404, text: '404 Not Found' },
+          2
+        ),
+        result('https://example.com/gone', { code: 410, text: '410 Gone' }, 3),
+        result(
+          'https://missing.invalid',
+          { text: 'DNS error: no records found' },
+          4
+        ),
+        result(
+          'https://example.com/blocked',
+          { code: 403, text: '403 Forbidden' },
+          5
+        ),
+        result(
+          'https://example.com/error',
+          { code: 500, text: '500 Server Error' },
+          6
+        ),
+        result(
+          'https://example.com/tls',
+          { text: 'SSL certificate not trusted' },
+          7
+        ),
+        result(
+          'https://example.com/reset',
+          { text: 'Network error: Connection reset by peer' },
+          8
+        ),
+        result(
+          'https://example.com/malformed',
+          { text: 'Invalid HTTP response format' },
+          9
+        ),
+        result(
+          'https://example.com/handshake',
+          { text: 'Network error: received fatal alert: HandshakeFailure' },
+          10
+        ),
+        result(
+          'https://example.com/unreachable',
+          {
+            text: 'Connection failed. Check network connectivity and firewall settings',
+          },
+          11
+        ),
+      ],
+    },
+    timeout_map: {
+      [source]: [result('https://example.com/slow', { text: 'Timeout' }, 12)],
+    },
+    redirect_map: {
+      [source]: [
+        {
+          origin: 'https://example.com/redirect',
+          redirects: [{ url: 'https://example.com/final', code: 301 }],
+        },
+      ],
+    },
+  });
+
+  assert.equal(classification.hardFailures.length, 3);
+  assert.equal(classification.manualReview.length, 2);
+  assert.equal(classification.automationWarnings.length, 6);
+  assert.equal(classification.redirectWarnings.length, 1);
+  assert.equal(classification.redirectWarnings[0].span.line, 1);
+  assert.ok(
+    classification.manualReview.some(
+      item => item.url === 'https://example.com/unreachable'
+    )
+  );
+  assert.ok(
+    classification.automationWarnings.some(
+      item => item.url === 'https://example.com/blocked'
+    )
+  );
+});
+
+test('creates a report with separate action and informational sections', () => {
+  const report = createReport(
+    classifyResults({
+      total: 3,
+      unique: 3,
+      successful: 0,
+      error_map: {
+        [source]: [
+          result(
+            'https://example.com/missing',
+            { code: 404, text: '404 Not Found' },
+            2
+          ),
+          result(
+            'https://example.com/blocked',
+            { code: 403, text: '403 Forbidden' },
+            3
+          ),
+          result(
+            'https://example.com/unreachable',
+            { text: 'Connection failed' },
+            4
+          ),
+        ],
+      },
+    })
+  );
+
+  assert.match(report, /Hard Failures \(1\)/);
+  assert.match(report, /Needs Manual Review \(1\)/);
+  assert.match(report, /Automation-Limited Observations \(1\)/);
+  assert.match(
+    report,
+    /Manual-review items open an issue without failing it\./
+  );
+});
+
+test('reads Lychee JSON from stdin and writes the report to stdout', () => {
+  const scriptPath = fileURLToPath(
+    new URL('./report-service-links.js', import.meta.url)
+  );
+  const run = spawnSync(process.execPath, [scriptPath], {
+    encoding: 'utf8',
+    input: JSON.stringify({
+      total: 1,
+      unique: 1,
+      successful: 0,
+      error_map: {
+        [source]: [
+          result(
+            'https://example.com/blocked',
+            { code: 403, text: '403 Forbidden' },
+            1
+          ),
+        ],
+      },
+    }),
+  });
+
+  assert.equal(run.status, 0, run.stderr);
+  assert.match(run.stdout, /Automation-Limited Observations \(1\)/);
+});


### PR DESCRIPTION
# What type of PR is this?

- [ ] Bug
- [ ] Change
- [x] Feature
- [ ] Miscellaneous

---

## What you changed and why?

<!-- State a short summary about what you changed or what is it about. -->

This automates the bi-monthly service link checks as mentioned in #681 with [Lychee](https://github.com/lycheeverse/lychee-action), with support for manual workflow runs. It classifies results into hard failures, manual-review candidates, and informational observations, then creates, updates, or closes a single tracking issue accordingly. Hard failures fail the workflow, while inconclusive automated checks are reported without failing it.

---

## Please specify which issue this PR Resolves (if applicable)

Refs #676 and its service-category sub-issues #677-#689.

---

## Checklist

- [x] I have performed a self-review of my own code.
- [x] These changes are now ready for review, or will be marked as draft.
- [x] This contribution was assisted by an AI agent. (if yes, please specify what agent is used under notes)

---

## Notes

<!-- Add video demos/screenshots, etc, other notes -->

- Checks all links in `src/data/services/*.json`.
- Only `404`, `410`, and DNS failures fail the workflow.
- Connection failures are reported for manual review without failing the workflow.
- Access restrictions, TLS errors, timeouts, resets, malformed responses, and redirects are informational.
- Link reachability does not confirm that the page still describes the intended service.
- Verified with `npm run test:service-links` and `npm run lint`.

---

## AI Disclosure

<!-- If no assistance from an AI agent, this section can be removed. -->

- This contribution was developed with the assistance of an AI coding tool: OpenCode, using GPT 5.6 Sol.
