### PR TITLE
feat(projects): update BetterLGU Directory title, description, and repository URL

### DIFF
--- a/public/api/projects.json
+++ b/public/api/projects.json
@@ -23,9 +23,9 @@
   },
   {
     "slug": "better-lgu",
-    "title": "Better LGU",
-    "description": "Directory and information platform for Philippine local government units, covering provinces, cities, and municipalities.",
-    "repositoryUrls": [],
+    "title": "BetterLGU Directory",
+    "description": "A community-run directory of Better LGU transparency portals — helping builders find existing efforts, contribute, and launch new ones.",
+    "repositoryUrls": ["https://github.com/jmacj/better-lgu-directory"],
     "projectUrl": "https://lgu.bettergov.ph",
     "status": "active",
     "repoType": "orgprojects",


### PR DESCRIPTION
# What type of PR is this?

- [ ] Bug
- [x] Change
- [ ] Feature
- [ ] Miscellaneous

---

## What you changed and why?

- Renamed the `better-lgu` project entry from "Better LGU" to "BetterLGU Directory" to match how the project is actually named and presented at https://lgu.bettergov.ph.
- Rewrote the description to reflect what the project actually is: a community-run directory of Better LGU transparency portals that helps builders find existing efforts, contribute to them, and launch new ones, instead of the previous generic "directory of provinces, cities, and municipalities" wording, which described a different thing.
- Added the source repository to `repositoryUrls` (`https://github.com/jmacj/better-lgu-directory`); the field was previously an empty array, so the project card had no way to link contributors to the codebase.

---

## Please specify which issue this PR Resolves (if applicable)

N/A

---

## Checklist

- [x] I have performed a self-review of my own code.
- [x] These changes are now ready for review, or will be marked as draft.
- [ ] This contribution was assisted by an AI agent. (if yes, please specify what agent is used under notes)

---

## Notes

- Data-only change; no component or route code touched.
- Verified the JSON still parses, and only the `better-lgu` object (plus the EOF newline) differs from `main`.