### PR TITLE
fix(seo): correct og:image URL and dimensions in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,11 +23,11 @@
 
     <meta
       property="og:image"
-      content="/logos/jpg/BetterGov_Vertical-White.jpg"
+      content="https://bettergov.ph/logos/jpg/BetterGov_Vertical-White.jpg"
     />
     <meta property="og:image:type" content="image/jpeg" />
-    <meta property="og:image:width" content="768" />
-    <meta property="og:image:height" content="768" />
+    <meta property="og:image:width" content="1080" />
+    <meta property="og:image:height" content="1080" />
     <meta property="og:type" content="website" />
   </head>
 


### PR DESCRIPTION
# What type of PR is this?

- [x] Bug
- [ ] Change
- [ ] Feature
- [ ] Miscellaneous

---

## What you changed and why?

- Fixed the Open Graph image meta tags in `index.html`:
  - `og:image` was a **relative** URL (`/logos/jpg/BetterGov_Vertical-White.jpg`). The OG spec (https://ogp.me) requires an absolute URL, so social crawlers (Facebook, X/Twitter, LinkedIn, Discord) may drop or mis-resolve the preview card. Changed to `https://bettergov.ph/logos/jpg/BetterGov_Vertical-White.jpg`.
  - `og:image:width` / `og:image:height` declared `768`×`768`, but the actual image file is **1080×1080** (verified locally), which can cause crawlers to crop or reject the preview. Updated to `1080`.
- Note: `src/components/SEO.tsx` was checked too — its `fullOgImage` already resolves the relative default against `baseUrl = 'https://bettergov.ph'`, so the rendered output there is already absolute. No change needed in that file; `index.html` was the only place emitting a relative `og:image` with wrong dimensions.

---

## Please specify which issue this PR Resolves (if applicable)

This PR closes #720

---

## Checklist

- [x] I have performed a self-review of my own code.
- [x] These changes are now ready for review, or will be marked as draft.
- [x] This contribution was assisted by an AI agent. (if yes, please specify what agent is used under notes)

---

## Notes

- Verified the source image dimensions (1080×1080) by reading the JPEG header of `public/logos/jpg/BetterGov_Vertical-White.jpg`.
- `npm run build` passes locally with these changes.
- No screenshots needed — change is limited to static meta tags.

---

## AI Disclosure

- This contribution was developed with the assistance of an AI coding tool: **Hermes Agent** (Nous Research).
