### PR TITLE
fix: deduplicate simultaneous API requests in fetchWithCache

### DIFF
--- a/src/lib/__tests__/api.test.ts
+++ b/src/lib/__tests__/api.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fetchWithCache } from '../api';
+
+describe('fetchWithCache', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should deduplicate simultaneous requests', async () => {
+    const mockFetch = vi.fn(
+      () =>
+        new Promise(resolve =>
+          setTimeout(
+            () =>
+              resolve({
+                ok: true,
+                json: () => Promise.resolve({ data: 'test' }),
+              }),
+            50
+          )
+        )
+    );
+
+    vi.stubGlobal('fetch', mockFetch);
+
+    const url = 'https://example.com/api';
+
+    const request1 = fetchWithCache(url);
+    const request2 = fetchWithCache(url);
+
+    const [result1, result2] = await Promise.all([request1, request2]);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(result1).toEqual({ data: 'test' });
+    expect(result2).toEqual({ data: 'test' });
+  });
+});

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,8 +1,9 @@
 // Create a cache for API responses
 type ApiCache = {
   [url: string]: {
-    data: unknown;
-    timestamp: number;
+    data?: unknown;
+    timestamp?: number;
+    promise?: Promise<unknown>;
   };
 };
 
@@ -14,31 +15,49 @@ const apiCache: ApiCache = {};
  * @param cacheDuration Duration in milliseconds to cache the data (default: 1 hour)
  * @returns The fetched data
  */
-export const fetchWithCache = async (
-  url: string,
-  cacheDuration = 60 * 60 * 1000
-) => {
+export const fetchWithCache = (url: string, cacheDuration = 60 * 60 * 1000) => {
   const now = Date.now();
 
   // Check if we have a cached response and it's still valid
-  if (apiCache[url] && now - apiCache[url].timestamp < cacheDuration) {
+  if (
+    apiCache[url]?.data &&
+    apiCache[url]?.timestamp &&
+    now - apiCache[url].timestamp < cacheDuration
+  ) {
     return apiCache[url].data;
   }
 
   // If no cache or expired, fetch new data
-  const response = await fetch(url);
-
-  if (!response.ok) {
-    throw new Error(`API request failed with status ${response.status}`);
+  // If a request is already in progress, wait for it
+  if (apiCache[url]?.promise) {
+    return apiCache[url].promise;
   }
 
-  const data = await response.json();
+  // Create a new request and store the promise immediately
+  const promise = fetch(url)
+    .then(response => {
+      if (!response.ok) {
+        throw new Error(`API request failed with status ${response.status}`);
+      }
 
-  // Cache the new data
+      return response.json();
+    })
+    .then(data => {
+      apiCache[url] = {
+        data,
+        timestamp: Date.now(),
+      };
+
+      return data;
+    })
+    .catch(error => {
+      delete apiCache[url];
+      throw error;
+    });
+
   apiCache[url] = {
-    data,
-    timestamp: now,
+    promise,
   };
 
-  return data;
+  return promise;
 };


### PR DESCRIPTION
# What type of PR is this?

- [x] Bug
- [ ] Change
- [ ] Feature
- [ ] Miscellaneous

---

## What you changed and why?

<!-- State a short summary about what you changed or what is it about. -->

- Fixed duplicate weather and forex API requests caused by concurrent calls to `fetchWithCache`.
- Added in-flight request deduplication by storing and reusing the active fetch Promise until it resolves.
- Added a regression test to ensure simultaneous requests only trigger a single network request.

---

## Please specify which issue this PR Resolves (if applicable)

This PR closes #721

---

## Checklist

- [x] I have performed a self-review of my own code.
- [x] These changes are now ready for review, or will be marked as draft.
- [x] This contribution was assisted by an AI agent. (if yes, please specify what agent is used under notes)

---

## Notes

- Verified that weather and forex requests are reduced from multiple duplicate calls to a single request each.
- Tested with:
  - `npm run test:unit`
  - `npm run build`

---

## AI Disclosure

- This contribution was developed with the assistance of an AI coding tool: "ChatGPT".