### PR TITLE
fix(assistant): escape regex metacharacters in Civic Assistant search

### DIFF
--- a/src/lib/__tests__/assistant.test.ts
+++ b/src/lib/__tests__/assistant.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { CivicEngine, escapeRegExp, type ServiceItem } from '../assistant';
+
+const sampleService = (service: string): ServiceItem => ({
+  service,
+  url: 'https://example.gov.ph',
+  id: '1',
+  slug: 'sample',
+  category: { name: 'Certificates', slug: 'certificates-ids' },
+  subcategory: { name: 'Civil Registry', slug: 'civil-registry' },
+});
+
+describe('assistant.ts', () => {
+  describe('escapeRegExp', () => {
+    it('escapes regex metacharacters', () => {
+      expect(escapeRegExp('birth (cenomar)')).toBe('birth \\(cenomar\\)');
+      expect(escapeRegExp('a+b*c?')).toBe('a\\+b\\*c\\?');
+    });
+  });
+
+  describe('CivicEngine.query', () => {
+    it('does not throw when the query contains regex metacharacters', () => {
+      const engine = new CivicEngine([
+        sampleService('Certificate of No Marriage (CENOMAR)'),
+      ]);
+
+      expect(() => engine.query('birth (cenomar)')).not.toThrow();
+      expect(() => engine.query('(CENOMAR)')).not.toThrow();
+      expect(engine.query('(CENOMAR)')).toHaveLength(1);
+    });
+
+    it('still ranks exact word matches above partial matches', () => {
+      const engine = new CivicEngine([
+        sampleService('Passport Application'),
+        sampleService('Passport Appointment'),
+      ]);
+
+      const results = engine.query('passport');
+      expect(results.length).toBeGreaterThan(0);
+      expect(results[0]?.service).toMatch(/Passport/);
+    });
+  });
+});

--- a/src/lib/assistant.ts
+++ b/src/lib/assistant.ts
@@ -14,6 +14,11 @@ export interface ServiceItem {
   };
 }
 
+/** Escape user input before interpolating into `new RegExp(...)`. */
+export function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 /**
  * Civic Assistant Logic
  * Performs client-side intent mapping and fuzzy search across curated JSON datasets.
@@ -21,7 +26,10 @@ export interface ServiceItem {
 export class CivicEngine {
   private data: ServiceItem[] = [];
 
-  constructor() {}
+  // ponytail: optional seed for unit tests; production uses initialize()
+  constructor(initialData: ServiceItem[] = []) {
+    this.data = initialData;
+  }
 
   async initialize() {
     try {
@@ -65,10 +73,12 @@ export class CivicEngine {
           `${item.service} ${item.category.name} ${item.subcategory.name}`.toLowerCase();
 
         searchTerms.forEach(term => {
-          if (target.includes(term)) {
-            score += 1;
-            // Exact word match bonus
-            if (new RegExp(`\\b${term}\\b`).test(target)) score += 2;
+          if (!term || !target.includes(term)) return;
+
+          score += 1;
+          // Exact word match bonus (escape so "(", "+", etc. cannot break RegExp)
+          if (new RegExp(`\\b${escapeRegExp(term)}\\b`).test(target)) {
+            score += 2;
           }
         });
 


### PR DESCRIPTION
## Summary
- Escape user search terms before building word-boundary RegExps in `CivicEngine.query`
- Add unit coverage so queries with `(`, `)`, `+`, etc. no longer throw

Fixes #729

## Test plan
- [x] `npm run test:unit -- src/lib/__tests__/assistant.test.ts`
- [ ] Open Civic Assistant and search for `birth (cenomar)` / `(CENOMAR)` — no console error, results still return