### PR TITLE
fix(seo): point page og:image tags at existing ph-logo.webp

### DIFF
--- a/src/pages/ContactUs.tsx
+++ b/src/pages/ContactUs.tsx
@@ -105,7 +105,7 @@ const ContactUs: FC = () => {
         />
         <meta property='og:type' content='website' />
         <meta property='og:url' content='https://bettergov.ph/contact' />
-        <meta property='og:image' content='https://bettergov.ph/ph-logo.png' />
+        <meta property='og:image' content='https://bettergov.ph/ph-logo.webp' />
       </Helmet>
 
       <div className='container mx-auto px-4 py-6 md:py-8'>

--- a/src/pages/Ideas.tsx
+++ b/src/pages/Ideas.tsx
@@ -134,7 +134,7 @@ const Ideas: FC = () => {
         />
         <meta property='og:type' content='website' />
         <meta property='og:url' content='https://bettergov.ph/ideas' />
-        <meta property='og:image' content='https://bettergov.ph/ph-logo.png' />
+        <meta property='og:image' content='https://bettergov.ph/ph-logo.webp' />
       </Helmet>
 
       <div className='container mx-auto px-4 py-6 md:py-12'>

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -25,7 +25,7 @@ export default function NotFound() {
         />
         <meta property='og:type' content='website' />
         <meta property='og:url' content='https://bettergov.ph/not-found' />
-        <meta property='og:image' content='https://bettergov.ph/ph-logo.png' />
+        <meta property='og:image' content='https://bettergov.ph/ph-logo.webp' />
       </Helmet>
 
       <div className='relative'>

--- a/src/pages/about/index.tsx
+++ b/src/pages/about/index.tsx
@@ -40,7 +40,7 @@ const AboutPage: FC = () => {
         />
         <meta property='og:type' content='website' />
         <meta property='og:url' content='https://bettergov.ph/about' />
-        <meta property='og:image' content='https://bettergov.ph/ph-logo.png' />
+        <meta property='og:image' content='https://bettergov.ph/ph-logo.webp' />
       </Helmet>
       <div className='container mx-auto px-4 py-6 md:py-8'>
         <div className='bg-white rounded-lg border shadow-xs p-6 md:p-8 md:py-24 mt-4'>

--- a/src/pages/services/index.tsx
+++ b/src/pages/services/index.tsx
@@ -249,7 +249,7 @@ export default function ServicesPage() {
         <meta property='og:description' content={metaDescription} />
         <meta property='og:type' content='website' />
         <meta property='og:url' content={canonicalUrl} />
-        <meta property='og:image' content='https://gov.ph/ph-logo.webp' />
+        <meta property='og:image' content='https://bettergov.ph/ph-logo.webp' />
       </Helmet>
       <div className='container mx-auto px-4 py-6 md:py-12'>
         {/* Header */}


### PR DESCRIPTION
## Summary
- Replace missing `ph-logo.png` Open Graph images with `ph-logo.webp` on Contact, About, Ideas, and NotFound
- Fix Services `og:image` pointing at `gov.ph` instead of `bettergov.ph`

Fixes #730

## Test plan
- [ ] Confirm `public/ph-logo.webp` exists and loads at `/ph-logo.webp`
- [ ] View page source / Helmet output on `/contact`, `/about`, `/ideas`, `/services`, and a 404 URL — `og:image` is `https://bettergov.ph/ph-logo.webp`
- [ ] Open that image URL in a browser (should not 404)