### PR TITLE
fix(a11y): add skip-to-main-content link in site layout

### DIFF
--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -22,13 +22,24 @@ test.describe('Accessibility', () => {
     expect(accessibilityScanResults.violations).toEqual([]);
   });
 
+  test('skip link moves focus to main content', async ({ page }) => {
+    await page.goto('/');
+
+    await page.keyboard.press('Tab');
+    const skipLink = page.getByRole('link', { name: /Skip to main content/i });
+    await expect(skipLink).toBeFocused();
+
+    await page.keyboard.press('Enter');
+    await expect(page.locator('#main-content')).toBeFocused();
+  });
+
   test('keyboard navigation should work', async ({ page }) => {
     await page.goto('/');
 
-    // Tab through interactive elements
+    // First Tab focuses the skip link; continue into the navbar
+    await page.keyboard.press('Tab');
     await page.keyboard.press('Tab');
 
-    // First tab should focus on Join Us link
     const focusedElement = await page.evaluate(
       () => document.activeElement?.textContent
     );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -98,167 +98,182 @@ function App() {
     <Router>
       <NuqsAdapter>
         <div className='min-h-screen flex flex-col'>
+          <a
+            href='#main-content'
+            className='sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-100 focus:rounded-md focus:bg-primary-600 focus:px-4 focus:py-2 focus:text-white focus:outline-hidden focus:ring-2 focus:ring-primary-600 focus:ring-offset-2'
+          >
+            Skip to main content
+          </a>
           <SEO />
           <Navbar />
           <Ticker />
           <ScrollToTop />
           <CivicAssistant />
-          <Routes>
-            <Route path='/' element={<Home />} />
-            <Route path='/design' element={<DesignGuide />} />
-            <Route path='/services' element={<Services />} />
-            <Route path='/about' element={<AboutPage />} />
-            <Route path='/contact' element={<ContactUs />} />
-            <Route path='/accessibility' element={<AccessibilityPage />} />
-            <Route path='/search' element={<SearchPage />} />
-            <Route path='/ideas' element={<Ideas />} />
-            <Route path='/join-us' element={<JoinUs />} />
-            <Route path='/terms-of-service' element={<TermsOfService />} />
-            <Route path='/sitemap' element={<SitemapPage />} />
-            <Route path='/discord' Component={Discord} />
-            <Route path='/projects' element={<Projects />} />
+          <main
+            id='main-content'
+            tabIndex={-1}
+            className='outline-none grow flex flex-col'
+          >
+            <Routes>
+              <Route path='/' element={<Home />} />
+              <Route path='/design' element={<DesignGuide />} />
+              <Route path='/services' element={<Services />} />
+              <Route path='/about' element={<AboutPage />} />
+              <Route path='/contact' element={<ContactUs />} />
+              <Route path='/accessibility' element={<AccessibilityPage />} />
+              <Route path='/search' element={<SearchPage />} />
+              <Route path='/ideas' element={<Ideas />} />
+              <Route path='/join-us' element={<JoinUs />} />
+              <Route path='/terms-of-service' element={<TermsOfService />} />
+              <Route path='/sitemap' element={<SitemapPage />} />
+              <Route path='/discord' Component={Discord} />
+              <Route path='/projects' element={<Projects />} />
 
-            <Route path='/philippines'>
-              <Route index element={<Navigate to='about' replace />} />
-              <Route path='about' element={<AboutPhilippines />} />
-              <Route path='history' element={<PhilippinesHistory />} />
-              <Route path='culture' element={<PhilippinesCulture />} />
-              <Route path='regions' element={<PhilippinesRegions />} />
-              <Route path='map' element={<PhilippinesMap />} />
-              <Route path='holidays' element={<PublicHolidays />} />
-              <Route path='hotlines' element={<Hotlines />} />
-            </Route>
+              <Route path='/philippines'>
+                <Route index element={<Navigate to='about' replace />} />
+                <Route path='about' element={<AboutPhilippines />} />
+                <Route path='history' element={<PhilippinesHistory />} />
+                <Route path='culture' element={<PhilippinesCulture />} />
+                <Route path='regions' element={<PhilippinesRegions />} />
+                <Route path='map' element={<PhilippinesMap />} />
+                <Route path='holidays' element={<PublicHolidays />} />
+                <Route path='hotlines' element={<Hotlines />} />
+              </Route>
 
-            {/* Data Routes */}
-            <Route path='/data/weather' element={<WeatherPage />} />
-            <Route path='/data/forex' element={<ForexPage />} />
-            <Route
-              path='/flood-control-projects'
-              element={<FloodControlProjects />}
-            />
-            <Route
-              path='/flood-control-projects/table'
-              element={<FloodControlProjectsTable />}
-            />
-            <Route
-              path='/flood-control-projects/map'
-              element={<FloodControlProjectsMap />}
-            />
-            <Route
-              path='/flood-control-projects/contractors'
-              element={<FloodControlProjectsContractors />}
-            />
-            <Route
-              path='/flood-control-projects/contractors/:contractor-name'
-              element={<ContractorDetail />}
-            />
-
-            {/* Services Routes */}
-            <Route path='/services/websites' element={<WebsitesDirectory />} />
-
-            {/* Travel Routes */}
-            <Route path='/travel'>
-              <Route index element={<Navigate to='visa' replace />} />
-              <Route path='visa' element={<VisaPage />} />
-              <Route path='visa-types' element={<VisaTypesPage />} />
+              {/* Data Routes */}
+              <Route path='/data/weather' element={<WeatherPage />} />
+              <Route path='/data/forex' element={<ForexPage />} />
               <Route
-                path='visa-types/:type'
-                element={
-                  <Suspense
-                    fallback={
-                      <div className='flex items-center justify-center min-h-screen'>
-                        Loading...
-                      </div>
-                    }
-                  >
-                    <VisaTypeDetail />
-                  </Suspense>
-                }
+                path='/flood-control-projects'
+                element={<FloodControlProjects />}
               />
-              <Route path='communicating' element={<CommunicatingPage />} />
               <Route
-                path='communicating/print'
-                element={<CommunicatingPrintPage />}
+                path='/flood-control-projects/table'
+                element={<FloodControlProjectsTable />}
               />
-            </Route>
+              <Route
+                path='/flood-control-projects/map'
+                element={<FloodControlProjectsMap />}
+              />
+              <Route
+                path='/flood-control-projects/contractors'
+                element={<FloodControlProjectsContractors />}
+              />
+              <Route
+                path='/flood-control-projects/contractors/:contractor-name'
+                element={<ContractorDetail />}
+              />
 
-            {/* Government Routes */}
-            <Route
-              path='/government'
-              element={<GovernmentLayout title='Government' />}
-            >
-              <Route index element={<Navigate to='executive' replace />} />
-              <Route path='salary-grade' element={<SalaryGradePage />} />
+              {/* Services Routes */}
+              <Route
+                path='/services/websites'
+                element={<WebsitesDirectory />}
+              />
 
-              <Route path='executive' element={<ExecutiveLayout />}>
-                <Route index element={<ExecutiveDirectory />} />
+              {/* Travel Routes */}
+              <Route path='/travel'>
+                <Route index element={<Navigate to='visa' replace />} />
+                <Route path='visa' element={<VisaPage />} />
+                <Route path='visa-types' element={<VisaTypesPage />} />
                 <Route
-                  path='other-executive-offices'
-                  element={<OtherExecutiveOffices />}
+                  path='visa-types/:type'
+                  element={
+                    <Suspense
+                      fallback={
+                        <div className='flex items-center justify-center min-h-screen'>
+                          Loading...
+                        </div>
+                      }
+                    >
+                      <VisaTypeDetail />
+                    </Suspense>
+                  }
                 />
+                <Route path='communicating' element={<CommunicatingPage />} />
                 <Route
-                  path='office-of-the-president'
-                  element={<OfficeOfThePresident />}
-                />
-                <Route
-                  path='office-of-the-vice-president'
-                  element={<OfficeOfTheVicePresident />}
-                />
-                <Route
-                  path='presidential-communications-office'
-                  element={<PresidentialCommunicationsOffice />}
-                />
-              </Route>
-
-              <Route path='departments' element={<DepartmentsLayout />}>
-                <Route index element={<DepartmentsIndex />} />
-                <Route path=':department' element={<DepartmentDetail />} />
-              </Route>
-
-              <Route path='constitutional' element={<ConstitutionalLayout />}>
-                <Route index element={<ConstitutionalIndex />} />
-                <Route path=':office' element={<ConstitutionalOffice />} />
-                <Route path='goccs' element={<GOCCsPage />} />
-                <Route path='sucs' element={<SUCsPage />} />
-              </Route>
-              <Route path='legislative' element={<LegislativeLayout />}>
-                <Route index element={<LegislativeIndex />} />
-                <Route path=':chamber' element={<LegislativeChamber />} />
-                <Route path='house-members' element={<HouseMembersPage />} />
-                <Route
-                  path='party-list-members'
-                  element={<PartyListMembersPage />}
-                />
-                <Route
-                  path='senate-committees'
-                  element={<SenateCommitteesPage />}
-                />
-              </Route>
-              <Route path='diplomatic' element={<DiplomaticLayout />}>
-                <Route index element={<DiplomaticIndex />} />
-                <Route path='missions' element={<DiplomaticMissionsPage />} />
-                <Route path='consulates' element={<ConsulatesPage />} />
-                <Route
-                  path='organizations'
-                  element={<InternationalOrganizationsPage />}
+                  path='communicating/print'
+                  element={<CommunicatingPrintPage />}
                 />
               </Route>
 
-              {/* Local Government Routes */}
-              <Route path='local' element={<LocalLayout />}>
-                <Route index element={<LocalGovernmentIndex />} />
-                <Route path=':region' element={<RegionalLGUPage />} />
+              {/* Government Routes */}
+              <Route
+                path='/government'
+                element={<GovernmentLayout title='Government' />}
+              >
+                <Route index element={<Navigate to='executive' replace />} />
+                <Route path='salary-grade' element={<SalaryGradePage />} />
+
+                <Route path='executive' element={<ExecutiveLayout />}>
+                  <Route index element={<ExecutiveDirectory />} />
+                  <Route
+                    path='other-executive-offices'
+                    element={<OtherExecutiveOffices />}
+                  />
+                  <Route
+                    path='office-of-the-president'
+                    element={<OfficeOfThePresident />}
+                  />
+                  <Route
+                    path='office-of-the-vice-president'
+                    element={<OfficeOfTheVicePresident />}
+                  />
+                  <Route
+                    path='presidential-communications-office'
+                    element={<PresidentialCommunicationsOffice />}
+                  />
+                </Route>
+
+                <Route path='departments' element={<DepartmentsLayout />}>
+                  <Route index element={<DepartmentsIndex />} />
+                  <Route path=':department' element={<DepartmentDetail />} />
+                </Route>
+
+                <Route path='constitutional' element={<ConstitutionalLayout />}>
+                  <Route index element={<ConstitutionalIndex />} />
+                  <Route path=':office' element={<ConstitutionalOffice />} />
+                  <Route path='goccs' element={<GOCCsPage />} />
+                  <Route path='sucs' element={<SUCsPage />} />
+                </Route>
+                <Route path='legislative' element={<LegislativeLayout />}>
+                  <Route index element={<LegislativeIndex />} />
+                  <Route path=':chamber' element={<LegislativeChamber />} />
+                  <Route path='house-members' element={<HouseMembersPage />} />
+                  <Route
+                    path='party-list-members'
+                    element={<PartyListMembersPage />}
+                  />
+                  <Route
+                    path='senate-committees'
+                    element={<SenateCommitteesPage />}
+                  />
+                </Route>
+                <Route path='diplomatic' element={<DiplomaticLayout />}>
+                  <Route index element={<DiplomaticIndex />} />
+                  <Route path='missions' element={<DiplomaticMissionsPage />} />
+                  <Route path='consulates' element={<ConsulatesPage />} />
+                  <Route
+                    path='organizations'
+                    element={<InternationalOrganizationsPage />}
+                  />
+                </Route>
+
+                {/* Local Government Routes */}
+                <Route path='local' element={<LocalLayout />}>
+                  <Route index element={<LocalGovernmentIndex />} />
+                  <Route path=':region' element={<RegionalLGUPage />} />
+                </Route>
+
+                <Route path='judicial' element={<JudicialLayout />}>
+                  <Route index element={<JudicialIndex />} />
+                  <Route path=':court' element={<JudicialIndex />} />
+                </Route>
               </Route>
 
-              <Route path='judicial' element={<JudicialLayout />}>
-                <Route index element={<JudicialIndex />} />
-                <Route path=':court' element={<JudicialIndex />} />
-              </Route>
-            </Route>
-
-            {/*Not Found/404 Page */}
-            <Route path='*' element={<NotFound />} />
-          </Routes>
+              {/*Not Found/404 Page */}
+              <Route path='*' element={<NotFound />} />
+            </Routes>
+          </main>
           <Footer />
         </div>
       </NuqsAdapter>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -9,7 +9,7 @@ import GovernmentSection from '../components/home/GovernmentSection';
 
 const Home: FC = () => {
   return (
-    <main className='grow'>
+    <div className='grow'>
       <JoinUsStrip />
       <Hero />
       <ServicesSection />
@@ -18,7 +18,7 @@ const Home: FC = () => {
       <JoinUsBanner />
       <PromotionBanner />
       <GovernmentSection />
-    </main>
+    </div>
   );
 };
 

--- a/src/pages/Ideas.tsx
+++ b/src/pages/Ideas.tsx
@@ -211,7 +211,7 @@ const Ideas: FC = () => {
         </div>
 
         {/* Project Ideas List */}
-        <main>
+        <section>
           <h2 className='text-2xl font-bold text-gray-900 mb-6'>
             All Project Ideas
           </h2>
@@ -267,7 +267,7 @@ const Ideas: FC = () => {
                 </Card>
               ))}
           </div>
-        </main>
+        </section>
 
         {/* Call to Action */}
         <section className='mt-12 text-center bg-white rounded-lg p-8 shadow-xs'>

--- a/src/pages/government/GovernmentPageContainer.tsx
+++ b/src/pages/government/GovernmentPageContainer.tsx
@@ -99,14 +99,14 @@ export default function GovernmentIndexPageContainer({
               {sidebar}
             </aside>
           )}
-          <main className='flex-1 min-w-0'>
+          <div className='flex-1 min-w-0'>
             <div
               id='government-content'
               className='bg-white rounded-lg border shadow-xs p-4 md:p-8'
             >
               {children}
             </div>
-          </main>
+          </div>
         </div>
       </div>
     </div>

--- a/src/pages/services/index.tsx
+++ b/src/pages/services/index.tsx
@@ -461,7 +461,7 @@ export default function ServicesPage() {
           </div>
 
           {/* Services Grid */}
-          <main className='flex-1'>
+          <div className='flex-1'>
             <h2 className='sr-only'>Available Services</h2>
             <div
               className='grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6'
@@ -577,7 +577,7 @@ export default function ServicesPage() {
               Showing {paginatedServices.length} of {filteredServices.length}{' '}
               services
             </div>
-          </main>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Add a focusable \"Skip to main content\" link as the first element in the app chrome
- Wrap routed page content in a single `<main id=\"main-content\">` landmark
- Remove nested page-level `<main>` tags that would conflict with the sitewide landmark
- Cover the skip-link focus path in Playwright accessibility tests

Fixes #731

## Test plan
- [ ] Open `/`, press Tab — focus lands on \"Skip to main content\"
- [ ] Press Enter — focus moves to `#main-content`
- [ ] Confirm `/accessibility` claims now match actual behavior
- [ ] Spot-check Home, Services, Ideas, and a government page for layout regressions