### PR TITLE
fix(csv-export): sanitize cell values to prevent formula injection

### DIFF
--- a/src/lib/__tests__/exportdata.test.ts
+++ b/src/lib/__tests__/exportdata.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { sanitizeCSVValue, exportToCSV } from '../exportData';
+
+function readBlobAsText(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = reject;
+    reader.readAsText(blob);
+  });
+}
+
+describe('sanitizeCSVValue', () => {
+  it('prefixes values starting with "=" to prevent formula execution', () => {
+    expect(sanitizeCSVValue('=SUM(A1:A10)')).toBe("'=SUM(A1:A10)");
+  });
+
+  it('prefixes values starting with "+"', () => {
+    expect(sanitizeCSVValue('+1234567890')).toBe("'+1234567890");
+  });
+
+  it('prefixes values starting with "-"', () => {
+    expect(sanitizeCSVValue('-2+3')).toBe("'-2+3");
+  });
+
+  it('prefixes values starting with "@"', () => {
+    expect(sanitizeCSVValue('@SUM(1+1)')).toBe("'@SUM(1+1)");
+  });
+
+  it('prefixes values starting with a tab character', () => {
+    expect(sanitizeCSVValue('\t=cmd')).toBe("'\t=cmd");
+  });
+
+  it('prefixes values starting with a carriage return', () => {
+    expect(sanitizeCSVValue('\rmalicious')).toBe("'\rmalicious");
+  });
+
+  it('does not alter safe values with internal hyphens', () => {
+    expect(sanitizeCSVValue('ABC-123-Contractor')).toBe('ABC-123-Contractor');
+  });
+
+  it('does not alter normal alphanumeric text', () => {
+    expect(sanitizeCSVValue('Flood Control Project Manila')).toBe(
+      'Flood Control Project Manila'
+    );
+  });
+
+  it('does not alter empty strings', () => {
+    expect(sanitizeCSVValue('')).toBe('');
+  });
+
+  it('does not alter numeric-looking strings that are not formulas', () => {
+    expect(sanitizeCSVValue('12345')).toBe('12345');
+  });
+});
+
+describe('exportToCSV formula injection protection (integration)', () => {
+  let createObjectURLSpy: ReturnType<typeof vi.fn>;
+  let clickSpy: ReturnType<typeof vi.fn>;
+  let capturedBlob: Blob | undefined;
+
+  beforeEach(() => {
+    capturedBlob = undefined;
+    createObjectURLSpy = vi.fn((blob: Blob) => {
+      capturedBlob = blob;
+      return 'blob:mock-url';
+    });
+    URL.createObjectURL =
+      createObjectURLSpy as unknown as typeof URL.createObjectURL;
+    URL.revokeObjectURL = vi.fn();
+
+    clickSpy = vi.fn();
+    const originalCreateElement = document.createElement.bind(document);
+    vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
+      const el = originalCreateElement(tag);
+      if (tag === 'a') {
+        el.click = clickSpy as unknown as () => void;
+      }
+      return el;
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('sanitizes a malicious cell before it reaches the CSV blob', async () => {
+    const maliciousData = [
+      {
+        project_title: '=HYPERLINK("http://evil.com","click")',
+        contractor: 'Safe Co',
+      },
+    ];
+
+    exportToCSV(maliciousData, 'test_export');
+
+    expect(capturedBlob).toBeDefined();
+    const text = await readBlobAsText(capturedBlob!);
+
+    expect(text).not.toContain('=HYPERLINK("http://evil.com","click")');
+    expect(text).toContain('\'=HYPERLINK(""http://evil.com"",""click"")');
+  });
+
+  it('still correctly escapes commas and quotes alongside sanitization', async () => {
+    const data = [{ notes: '=1+1,"danger"' }];
+
+    exportToCSV(data, 'test_export');
+
+    const text = await readBlobAsText(capturedBlob!);
+    expect(text).toContain('"\'=1+1,""danger"""');
+  });
+
+  it('leaves normal safe data completely unchanged', async () => {
+    const data = [{ project_title: 'Manila Flood Wall', region: 'NCR' }];
+
+    exportToCSV(data, 'test_export');
+
+    const text = await readBlobAsText(capturedBlob!);
+    expect(text).toContain('project_title,region');
+    expect(text).toContain('Manila Flood Wall,NCR');
+  });
+});

--- a/src/lib/exportData.ts
+++ b/src/lib/exportData.ts
@@ -3,6 +3,19 @@
  */
 
 /**
+ * Sanitizes a CSV cell value to prevent formula injection (CWE-1236 / OWASP CSV Injection).
+ * Spreadsheet applications (Excel, Google Sheets, LibreOffice) may interpret cell values
+ * starting with '=', '+', '-', '@', tab, or carriage return as formulas.
+ * Prefixing with a single quote neutralizes this without destroying the original data.
+ */
+export function sanitizeCSVValue(valueStr: string): string {
+  if (/^[=+\-@\t\r]/.test(valueStr)) {
+    return `'${valueStr}`;
+  }
+  return valueStr;
+}
+
+/**
  * Exports data to CSV format and triggers download
  * @param data Array of objects to export
  * @param filename Name of the file to download
@@ -32,7 +45,7 @@ export function exportToCSV(
             row[header] === null || row[header] === undefined
               ? ''
               : row[header];
-          const valueStr = String(value);
+          const valueStr = sanitizeCSVValue(String(value));
 
           if (
             valueStr.includes(',') ||


### PR DESCRIPTION
Prefix CSV cell values starting with `=`, `+`, `-`, `@`, tab, or carriage return with a single quote before writing to the exported CSV file. Prevents spreadsheet apps (Excel, Google Sheets, LibreOffice) from interpreting untrusted data as executable formulas (CWE-1236 / OWASP CSV Injection).

* Add `sanitizeCSVValue()` in `src/lib/exportData.ts`
* Apply it to every cell value in `exportToCSV()` before existing comma/quote/newline escaping
* Add unit + integration tests covering sanitization and its interaction with existing quoting rules

# What type of PR is this?

* [x] Bug
* [ ] Change
* [ ] Feature
* [ ] Miscellaneous

---

## What you changed and why?

* Sanitized CSV cell values that begin with spreadsheet formula characters (`=`, `+`, `-`, `@`, tab, or carriage return).
* Added unit tests covering all supported formula-injection prefixes and safe values.
* Added integration tests to verify sanitization works correctly with the existing CSV quoting and escaping logic.
* This prevents untrusted CSV data from being interpreted as executable formulas when opened in spreadsheet applications.

---

## Please specify which issue this PR Resolves (if applicable)

This PR closes #719

---

## Checklist

* [x] I have performed a self-review of my own code.
* [x] These changes are now ready for review, or will be marked as draft.
* [x] This contribution was assisted by an AI agent. (if yes, please specify what agent is used under notes)

---

## Notes

* `npm run test:unit` — 20 tests passed.
* `npm run build` — passed successfully.
* Changes are limited to `src/lib/exportData.ts` and its corresponding tests.

---

## AI Disclosure

* This contribution was developed with the assistance of AI coding tools: "Claude".
