### PR TITLE
feat: add a /contribute page indexing every way to contribute

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -44,6 +44,7 @@
     "joinMovement": "Join Our Movement",
     "or": "or",
     "joinDiscord": "Join Discord",
+    "findWayToContribute": "Find a Way to Contribute",
     "features": "🚀 Infrastructure • 💡 Mentorship • 🤝 Community • 🏢 Office Space"
   },
   "data": {

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -278,6 +278,7 @@ function generateSiteUrls(mainNavigation, governmentData) {
   const mainPages = [
     { url: `${siteUrl}/`, priority: '1.0', changefreq: 'daily' },
     { url: `${siteUrl}/about`, priority: '0.8', changefreq: 'monthly' },
+    { url: `${siteUrl}/contribute`, priority: '0.7', changefreq: 'monthly' },
     { url: `${siteUrl}/search`, priority: '0.9', changefreq: 'weekly' },
     { url: `${siteUrl}/services`, priority: '0.9', changefreq: 'weekly' },
     { url: `${siteUrl}/sitemap`, priority: '0.5', changefreq: 'monthly' },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -115,11 +115,6 @@ function App() {
             <Route path='/ideas' element={<Ideas />} />
             <Route path='/join-us' element={<JoinUs />} />
             <Route path='/contribute' element={<Contribute />} />
-            {/* Issue #54 named this page /contributing; keep that address working. */}
-            <Route
-              path='/contributing'
-              element={<Navigate to='/contribute' replace />}
-            />
             <Route path='/terms-of-service' element={<TermsOfService />} />
             <Route path='/sitemap' element={<SitemapPage />} />
             <Route path='/discord' Component={Discord} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -92,6 +92,7 @@ import Discord from './pages/Discord';
 import SalaryGradePage from './pages/government/salary-grade/index';
 import CivicAssistant from './components/ui/CivicAssistant';
 import NotFound from './pages/NotFound';
+import Contribute from './pages/contribute';
 
 function App() {
   return (
@@ -113,6 +114,12 @@ function App() {
             <Route path='/search' element={<SearchPage />} />
             <Route path='/ideas' element={<Ideas />} />
             <Route path='/join-us' element={<JoinUs />} />
+            <Route path='/contribute' element={<Contribute />} />
+            {/* Issue #54 named this page /contributing; keep that address working. */}
+            <Route
+              path='/contributing'
+              element={<Navigate to='/contribute' replace />}
+            />
             <Route path='/terms-of-service' element={<TermsOfService />} />
             <Route path='/sitemap' element={<SitemapPage />} />
             <Route path='/discord' Component={Discord} />

--- a/src/components/home/JoinUsBanner.tsx
+++ b/src/components/home/JoinUsBanner.tsx
@@ -1,8 +1,12 @@
-import { ArrowRightIcon, UsersIcon, ZapIcon } from 'lucide-react';
+import {
+  ArrowRightIcon,
+  LightbulbIcon,
+  UsersIcon,
+  ZapIcon,
+} from 'lucide-react';
 import { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
-import { SiDiscord } from '@icons-pack/react-simple-icons';
 
 const JoinUsBanner: FC = () => {
   const { t } = useTranslation('common');
@@ -53,15 +57,13 @@ const JoinUsBanner: FC = () => {
 
             <div className='text-orange-100 font-medium'>{t('joinUs.or')}</div>
 
-            <a
-              href='https://discord.gg/mHtThpN8bT'
-              target='_blank'
-              rel='noreferrer'
+            <Link
+              to='/contribute'
               className='inline-flex items-center justify-center px-6 py-3 border-2 border-white text-white font-semibold rounded-lg hover:bg-white hover:text-gray-900 transition-all'
             >
-              <SiDiscord className='h-5 w-5 mr-2' />
-              {t('joinUs.joinDiscord')}
-            </a>
+              <LightbulbIcon className='h-5 w-5 mr-2' />
+              {t('joinUs.findWayToContribute')}
+            </Link>
           </div>
 
           <div className='mt-8 pt-6 border-t border-white/20'>

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -167,6 +167,7 @@ export const footerNavigation = {
         { label: 'About the Portal', href: '/about' },
         { label: 'About BetterGov.ph', href: 'https://about.bettergov.ph' },
         { label: 'Documentation', href: 'https://docs.bettergov.ph/' },
+        { label: 'Contribute', href: '/contribute' },
         { label: 'Project Ideas', href: '/ideas' },
         { label: 'Accessibility', href: '/accessibility' },
         { label: 'Terms of Use', href: '/terms-of-service' },

--- a/src/data/seo-metadata.json
+++ b/src/data/seo-metadata.json
@@ -11,6 +11,10 @@
     "title": "Accessibility Statement | BetterGov.ph | BetterGov.ph",
     "description": "Find important information about Accessibility Statement through BetterGov.ph, the Philippines\u2019 civic information portal."
   },
+  "/contribute": {
+    "title": "Contribute | BetterGov.ph",
+    "description": "Every way to contribute to BetterGov.ph, ordered from easiest to hardest: join the Discord, report a problem, share an idea, fix data, write code, review pull requests, or list your own civic tech project."
+  },
   "/data/forex": {
     "title": "Forex: Currency Converter - BetterGov.ph",
     "description": "Find important information about Forex: Currency Converter through BetterGov.ph, the Philippines\u2019 civic information portal."

--- a/src/pages/JoinUs.tsx
+++ b/src/pages/JoinUs.tsx
@@ -15,6 +15,7 @@ import {
 import { SiDiscord } from '@icons-pack/react-simple-icons';
 import { FC } from 'react';
 import { Helmet } from 'react-helmet-async';
+import { Link } from 'react-router-dom';
 
 const JoinUs: FC = () => {
   return (
@@ -274,15 +275,13 @@ const JoinUs: FC = () => {
 
               <div className='text-white font-medium'>or</div>
 
-              <a
-                href='https://bettergov.ph/ideas'
-                target='_blank'
-                rel='noreferrer'
+              <Link
+                to='/contribute'
                 className='inline-flex items-center justify-center px-8 py-4 border-2 border-white text-white font-semibold rounded-lg hover:bg-white hover:text-primary-600 transition-all'
               >
                 <LightbulbIcon className='h-5 w-5 mr-2' />
-                Explore Project Ideas
-              </a>
+                Find a Way to Contribute
+              </Link>
             </div>
 
             <div className='mt-8 pt-6 border-t border-white/20'>

--- a/src/pages/contribute/ContributeHero.tsx
+++ b/src/pages/contribute/ContributeHero.tsx
@@ -1,0 +1,62 @@
+import { SiDiscord } from '@icons-pack/react-simple-icons';
+import { FC } from 'react';
+import { Link } from 'react-router-dom';
+
+/**
+ * Follows the front page's own hero pattern (primary gradient, two columns,
+ * glass panel) so the page reads as native rather than invented. The panel
+ * holds the lowest-commitment action, which is also the one the list below
+ * opens with.
+ */
+const MODES = ['Join in', 'Fix data', 'Write code', 'Build your own'];
+
+export const ContributeHero: FC = () => (
+  <section className='bg-linear-to-r from-primary-600 to-primary-700 text-white'>
+    {/* max-w-4xl so the hero's left edge lines up with the list below it. The
+        front page hero is full-container, but nothing sits under it. */}
+    <div className='container mx-auto px-4 max-w-4xl py-12 md:py-20'>
+      <div className='grid grid-cols-1 lg:grid-cols-2 gap-8 items-center'>
+        <div className='animate-fade-in'>
+          <h1 className='text-3xl md:text-4xl lg:text-5xl font-bold mb-4 leading-tight'>
+            Contribute to BetterGov.ph
+          </h1>
+          <p className='text-lg text-blue-100 mb-6 max-w-lg'>
+            Volunteer-led, open source, and always short of hands. Every current
+            way in is on this page, ordered by how much it asks of you.
+          </p>
+          <ul className='flex flex-wrap gap-2 list-none p-0 m-0'>
+            {MODES.map(mode => (
+              <li
+                key={mode}
+                className='bg-white/10 text-white border border-white/20 py-2 px-4 rounded-xl text-sm'
+              >
+                {mode}
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div className='bg-white/10 backdrop-blur-xs rounded-xl p-6 shadow-lg animate-slide-in'>
+          <h2 className='text-2xl font-semibold mb-2'>
+            Not sure where to fit?
+          </h2>
+          <p className='text-blue-100 mb-5'>
+            Start in the Discord. It costs nothing, needs no technical skill,
+            and everything else on this page starts there anyway.
+          </p>
+          <Link
+            to='/discord'
+            className='inline-flex items-center justify-center w-full px-6 py-3 bg-yellow-400 text-gray-900 font-bold rounded-lg hover:bg-yellow-300 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white transition-all'
+          >
+            <SiDiscord className='h-5 w-5 mr-2' aria-hidden='true' />
+            Start in the Discord
+          </Link>
+          <p className='text-blue-100 text-sm mt-4'>
+            Already know what you want to do? The list below is ordered easiest
+            first.
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+);

--- a/src/pages/contribute/ContributeHero.tsx
+++ b/src/pages/contribute/ContributeHero.tsx
@@ -14,8 +14,8 @@ export const ContributeHero: FC = () => (
             Contribute to BetterGov.ph
           </h1>
           <p className='text-lg text-blue-100 mb-6 max-w-lg'>
-            Volunteer-led, open source, and always short of hands. Every current
-            way in is on this page, ordered by how much it asks of you.
+            Volunteer-led. Open source. Community-driven. Every current way in
+            is on this page, ordered by how much it asks of you.
           </p>
           <ul className='flex flex-wrap gap-2 list-none p-0 m-0'>
             {MODES.map(mode => (

--- a/src/pages/contribute/ContributeHero.tsx
+++ b/src/pages/contribute/ContributeHero.tsx
@@ -2,18 +2,11 @@ import { SiDiscord } from '@icons-pack/react-simple-icons';
 import { FC } from 'react';
 import { Link } from 'react-router-dom';
 
-/**
- * Follows the front page's own hero pattern (primary gradient, two columns,
- * glass panel) so the page reads as native rather than invented. The panel
- * holds the lowest-commitment action, which is also the one the list below
- * opens with.
- */
 const MODES = ['Join in', 'Fix data', 'Write code', 'Build your own'];
 
 export const ContributeHero: FC = () => (
   <section className='bg-linear-to-r from-primary-600 to-primary-700 text-white'>
-    {/* max-w-4xl so the hero's left edge lines up with the list below it. The
-        front page hero is full-container, but nothing sits under it. */}
+    {/* max-w-4xl to line the hero up with the list below it */}
     <div className='container mx-auto px-4 max-w-4xl py-12 md:py-20'>
       <div className='grid grid-cols-1 lg:grid-cols-2 gap-8 items-center'>
         <div className='animate-fade-in'>

--- a/src/pages/contribute/ContributeRouter.tsx
+++ b/src/pages/contribute/ContributeRouter.tsx
@@ -1,0 +1,130 @@
+import { ArrowRightIcon, ExternalLinkIcon, MailIcon } from 'lucide-react';
+import { FC } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  ENTRY_POINTS,
+  EntryPoint,
+  EntryPointAction,
+  INTRO,
+  linkKind,
+} from './entryPoints';
+
+/**
+ * What each entry point costs the reader, in the only unit that never goes
+ * stale: their time.
+ */
+const COMMITMENT_LABEL: Record<EntryPoint['commitment'], string> = {
+  1: 'Minutes',
+  2: 'Minutes',
+  3: 'An hour',
+  4: 'An evening',
+  5: 'Ongoing',
+};
+
+/**
+ * A single destination. The row cannot be one big link: rows with a second
+ * channel would need a link nested inside a link, which is invalid HTML.
+ * The cost is that the whole row is no longer a single tap target.
+ */
+const Action: FC<EntryPointAction & { primary?: boolean }> = ({
+  action,
+  href,
+  primary = false,
+}) => {
+  const kind = linkKind(href);
+
+  const className = primary
+    ? 'group inline-flex items-center gap-1.5 text-primary-600 font-semibold hover:gap-2.5 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 rounded-xs transition-all'
+    : 'inline-flex items-center text-sm text-gray-500 hover:text-primary-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 rounded-xs underline underline-offset-2';
+
+  const Icon =
+    kind === 'external'
+      ? ExternalLinkIcon
+      : kind === 'email'
+        ? MailIcon
+        : ArrowRightIcon;
+
+  const icon = primary && <Icon className='h-4 w-4' aria-hidden='true' />;
+
+  if (kind === 'internal') {
+    return (
+      <Link to={href} className={className}>
+        {action}
+        {icon}
+      </Link>
+    );
+  }
+
+  // mailto: hands off to a mail client, so a new tab would leave a blank one behind.
+  const newTab = kind === 'external';
+
+  return (
+    <a
+      href={href}
+      className={className}
+      {...(newTab ? { target: '_blank', rel: 'noreferrer' } : {})}
+    >
+      {action}
+      {/* The whole page is a list of links, half of them off-site. The icon
+          only rides on the primary action, so the warning has to be spoken. */}
+      {newTab && <span className='sr-only'> (opens in a new tab)</span>}
+      {icon}
+    </a>
+  );
+};
+
+const Row: FC<{ entry: EntryPoint }> = ({ entry }) => (
+  <li className='flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-6 p-5 bg-white border border-gray-200 rounded-xl hover:border-primary-400 hover:shadow-sm transition-all'>
+    <div className='flex-1'>
+      <div className='flex items-center gap-2 mb-1'>
+        <h3 className='text-xs font-semibold uppercase tracking-wide text-primary-600'>
+          {entry.modeLabel}
+        </h3>
+        <span className='text-xs text-gray-400'>
+          · {COMMITMENT_LABEL[entry.commitment]}
+        </span>
+      </div>
+      <p className='text-gray-900 font-medium leading-snug'>{entry.who}</p>
+      {entry.note && <p className='text-sm text-gray-500 mt-1'>{entry.note}</p>}
+    </div>
+
+    <div className='shrink-0 flex flex-col sm:items-end gap-1'>
+      <Action action={entry.action} href={entry.href} primary />
+      {entry.alt && <Action action={entry.alt.action} href={entry.alt.href} />}
+    </div>
+  </li>
+);
+
+export const ContributeRouter: FC = () => (
+  <div className='container mx-auto px-4 max-w-4xl'>
+    <div className='mb-8'>
+      <p className='text-sm font-bold uppercase tracking-wider text-primary-600 mb-2'>
+        {INTRO.eyebrow}
+      </p>
+      <h2
+        id='ways-to-help-heading'
+        className='text-3xl md:text-4xl font-bold text-gray-900 mb-3'
+      >
+        {INTRO.heading}
+      </h2>
+      <p className='text-lg text-gray-600 max-w-2xl'>{INTRO.standfirst}</p>
+    </div>
+
+    <ul
+      aria-label='Ways to contribute'
+      className='flex flex-col gap-3 list-none p-0 m-0'
+    >
+      {ENTRY_POINTS.map(entry => (
+        <Row key={entry.id} entry={entry} />
+      ))}
+    </ul>
+
+    <p className='text-sm text-gray-500 mt-8'>
+      Not sure which one fits? Ask in the{' '}
+      <Link to='/discord' className='text-primary-600 underline'>
+        Discord
+      </Link>
+      .
+    </p>
+  </div>
+);

--- a/src/pages/contribute/ContributeRouter.tsx
+++ b/src/pages/contribute/ContributeRouter.tsx
@@ -9,10 +9,6 @@ import {
   linkKind,
 } from './entryPoints';
 
-/**
- * What each entry point costs the reader, in the only unit that never goes
- * stale: their time.
- */
 const COMMITMENT_LABEL: Record<EntryPoint['commitment'], string> = {
   1: 'Minutes',
   2: 'Minutes',
@@ -21,11 +17,7 @@ const COMMITMENT_LABEL: Record<EntryPoint['commitment'], string> = {
   5: 'Ongoing',
 };
 
-/**
- * A single destination. The row cannot be one big link: rows with a second
- * channel would need a link nested inside a link, which is invalid HTML.
- * The cost is that the whole row is no longer a single tap target.
- */
+// Rows carry up to two actions, so the row itself cannot be one big link.
 const Action: FC<EntryPointAction & { primary?: boolean }> = ({
   action,
   href,
@@ -65,8 +57,7 @@ const Action: FC<EntryPointAction & { primary?: boolean }> = ({
       {...(newTab ? { target: '_blank', rel: 'noreferrer' } : {})}
     >
       {action}
-      {/* The whole page is a list of links, half of them off-site. The icon
-          only rides on the primary action, so the warning has to be spoken. */}
+      {/* New tab warning for screen readers */}
       {newTab && <span className='sr-only'> (opens in a new tab)</span>}
       {icon}
     </a>

--- a/src/pages/contribute/__tests__/Contribute.test.tsx
+++ b/src/pages/contribute/__tests__/Contribute.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen, within } from '@testing-library/react';
+import { HelmetProvider } from 'react-helmet-async';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import Contribute from '..';
+import { ENTRY_POINTS } from '../entryPoints';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: 'en', resolvedLanguage: 'en' },
+  }),
+}));
+
+const renderPage = () =>
+  render(
+    <HelmetProvider>
+      <MemoryRouter initialEntries={['/contribute']}>
+        <Contribute />
+      </MemoryRouter>
+    </HelmetProvider>
+  );
+
+describe('Contribute', () => {
+  it('names the page once, in the hero', () => {
+    renderPage();
+
+    expect(
+      screen.getByRole('heading', {
+        level: 1,
+        name: /contribute to bettergov/i,
+      })
+    ).toBeInTheDocument();
+  });
+
+  /** Off-site actions carry an appended sr-only new-tab warning. */
+  const linkFor = (action: string) =>
+    screen.getByRole('link', { name: name => name.startsWith(action) });
+
+  it('renders every entry point as its own action', () => {
+    renderPage();
+
+    for (const entry of ENTRY_POINTS) {
+      expect(linkFor(entry.action), entry.id).toBeInTheDocument();
+    }
+  });
+
+  it('lists the entry points in commitment order', () => {
+    renderPage();
+
+    const list = screen.getByRole('list', { name: /ways to contribute/i });
+    const rendered = within(list)
+      .getAllByRole('listitem')
+      .map(item => within(item).getByRole('heading').textContent);
+
+    expect(rendered).toEqual(ENTRY_POINTS.map(entry => entry.modeLabel));
+  });
+
+  it('opens off-site destinations in a new tab, and site pages in place', () => {
+    renderPage();
+
+    const offSite = linkFor('Review an open pull request');
+
+    expect(offSite).toHaveAttribute('target', '_blank');
+    expect(offSite).toHaveAccessibleName(/opens in a new tab/i);
+    expect(linkFor('Join the Discord')).toHaveAttribute('href', '/discord');
+  });
+
+  it('links the volunteers address as a mail client handoff, not a new tab', () => {
+    renderPage();
+
+    const email = linkFor('Email the volunteers');
+
+    expect(email).toHaveAttribute('href', 'mailto:volunteers@bettergov.ph');
+    expect(email).not.toHaveAttribute('target');
+  });
+});

--- a/src/pages/contribute/__tests__/Contribute.test.tsx
+++ b/src/pages/contribute/__tests__/Contribute.test.tsx
@@ -33,7 +33,7 @@ describe('Contribute', () => {
     ).toBeInTheDocument();
   });
 
-  /** Off-site actions carry an appended sr-only new-tab warning. */
+  // Off-site actions append an sr-only new-tab warning to their name.
   const linkFor = (action: string) =>
     screen.getByRole('link', { name: name => name.startsWith(action) });
 

--- a/src/pages/contribute/__tests__/entryPoints.test.ts
+++ b/src/pages/contribute/__tests__/entryPoints.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { ENTRY_POINTS, INTRO, linkKind } from '../entryPoints';
+
+/**
+ * The page's promise is "every way in, easiest first". These invariants are
+ * that promise, expressed as tests: the order is the content, so it cannot be
+ * left to whoever edits the array next.
+ */
+describe('linkKind', () => {
+  it('classifies a site-relative path as internal', () => {
+    expect(linkKind('/discord')).toBe('internal');
+  });
+
+  it('classifies a mailto: href as email', () => {
+    expect(linkKind('mailto:volunteers@bettergov.ph')).toBe('email');
+  });
+
+  it('classifies an absolute URL as external', () => {
+    expect(linkKind('https://github.com/bettergovph/bettergov')).toBe(
+      'external'
+    );
+  });
+});
+
+describe('ENTRY_POINTS', () => {
+  it('is ordered by commitment, lowest first', () => {
+    const commitments = ENTRY_POINTS.map(entry => entry.commitment);
+
+    expect(commitments).toEqual([...commitments].sort((a, b) => a - b));
+  });
+
+  it('has a unique id per entry', () => {
+    const ids = ENTRY_POINTS.map(entry => entry.id);
+
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('routes every action somewhere resolvable', () => {
+    for (const entry of ENTRY_POINTS) {
+      expect(linkKind(entry.href), entry.id).toBeDefined();
+      if (entry.alt) expect(linkKind(entry.alt.href), entry.id).toBeDefined();
+    }
+  });
+
+  it('offers the volunteers mailing address as its own entry point', () => {
+    const email = ENTRY_POINTS.find(
+      entry => entry.href === 'mailto:volunteers@bettergov.ph'
+    );
+
+    expect(email).toBeDefined();
+  });
+
+  it('carries no em dashes in copy the reader sees', () => {
+    const copy = [
+      INTRO.eyebrow,
+      INTRO.heading,
+      INTRO.standfirst,
+      ...ENTRY_POINTS.flatMap(entry => [
+        entry.modeLabel,
+        entry.who,
+        entry.action,
+        entry.note ?? '',
+        entry.alt?.action ?? '',
+      ]),
+    ].join(' ');
+
+    expect(copy).not.toContain('—');
+  });
+});

--- a/src/pages/contribute/__tests__/entryPoints.test.ts
+++ b/src/pages/contribute/__tests__/entryPoints.test.ts
@@ -1,11 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { ENTRY_POINTS, INTRO, linkKind } from '../entryPoints';
 
-/**
- * The page's promise is "every way in, easiest first". These invariants are
- * that promise, expressed as tests: the order is the content, so it cannot be
- * left to whoever edits the array next.
- */
 describe('linkKind', () => {
   it('classifies a site-relative path as internal', () => {
     expect(linkKind('/discord')).toBe('internal');

--- a/src/pages/contribute/entryPoints.ts
+++ b/src/pages/contribute/entryPoints.ts
@@ -1,0 +1,180 @@
+/**
+ * The entry-point index behind /contribute.
+ *
+ * Contributing to BetterGov is not contributing to one repository. Every
+ * destination below already exists somewhere on this site or on GitHub; what
+ * did not exist was a single place that routes between them. This page is an
+ * index, not a new surface, so it duplicates no CTA and asserts no priority.
+ *
+ * Two rules keep it evergreen, which matters because it has no dedicated
+ * owner:
+ *
+ *   1. Ordering is by COMMITMENT, lowest first. Ranking by "what the project
+ *      needs most" would need a curator and would rot the moment nobody
+ *      curates it.
+ *   2. No counts, no dates, no live data. A link cannot go stale the way a
+ *      rendered issue count can.
+ */
+
+export type Mode =
+  | 'community'
+  | 'report'
+  | 'ideas'
+  | 'code'
+  | 'review'
+  | 'project';
+
+/** How a destination must be rendered. Derived from the href so it cannot drift. */
+export type LinkKind = 'internal' | 'external' | 'email';
+
+export const linkKind = (href: string): LinkKind => {
+  if (href.startsWith('mailto:')) return 'email';
+  return href.startsWith('/') ? 'internal' : 'external';
+};
+
+export interface EntryPointAction {
+  action: string;
+  href: string;
+}
+
+export interface EntryPoint extends EntryPointAction {
+  id: string;
+  /** Ascending commitment. Drives display order. */
+  commitment: 1 | 2 | 3 | 4 | 5;
+  mode: Mode;
+  modeLabel: string;
+  /** "Is this you?" is the router's actual job. */
+  who: string;
+  /**
+   * Second channel for the same job. Reporting and ideas both accept GitHub or
+   * Discord, because forcing a GitHub account on someone who only wants to say
+   * "this number is wrong" loses the report. The primary is the channel that
+   * leaves a durable record; the alternate is the lower-friction one.
+   */
+  alt?: EntryPointAction;
+  /** Small muted note. Must be evergreen: no counts, no dates. */
+  note?: string;
+}
+
+const REPO = 'https://github.com/bettergovph/bettergov';
+
+export const ENTRY_POINTS: EntryPoint[] = [
+  {
+    id: 'discord',
+    commitment: 1,
+    mode: 'community',
+    modeLabel: 'Community',
+    who: 'You want to see what people are working on before committing to anything.',
+    action: 'Join the Discord',
+    href: '/discord',
+    note: 'Everything else starts here. No technical skill needed.',
+  },
+  {
+    id: 'email',
+    commitment: 1,
+    mode: 'community',
+    modeLabel: 'Email',
+    who: 'You would rather write to a person than join a chat server.',
+    action: 'Email the volunteers',
+    href: 'mailto:volunteers@bettergov.ph',
+    note: 'Goes to the volunteer team. Good for offers of help that do not fit a form.',
+  },
+  {
+    id: 'report',
+    commitment: 2,
+    mode: 'report',
+    modeLabel: 'Report',
+    who: 'You spotted something wrong. A broken page, outdated info, a wrong number.',
+    action: 'Open a bug report',
+    href: `${REPO}/issues/new?template=bug_report.md`,
+    alt: { action: 'or say it in Discord', href: '/discord' },
+    note: 'GitHub keeps a record others can pick up. Discord works if you have no account.',
+  },
+  {
+    id: 'ideas',
+    commitment: 2,
+    mode: 'ideas',
+    modeLabel: 'Ideas',
+    who: 'You have an idea for something BetterGov should build.',
+    action: 'Share an idea',
+    href: '/ideas',
+    alt: { action: 'or talk it through in Discord', href: '/discord' },
+    note: 'The form files it as a GitHub issue. Discord is better for half-formed ideas.',
+  },
+  {
+    id: 'data',
+    commitment: 3,
+    mode: 'code',
+    modeLabel: 'Data',
+    who: 'You can fix or add government data: directories, hotlines, services.',
+    action: 'Browse the data files',
+    href: `${REPO}/tree/main/src/data`,
+    note: 'Plain JSON. Edit on GitHub without cloning anything.',
+  },
+  {
+    id: 'code',
+    commitment: 4,
+    mode: 'code',
+    modeLabel: 'Code',
+    who: 'You write code and want a scoped first task.',
+    action: 'Find a good first issue',
+    href: `${REPO}/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22`,
+    note: 'Read CONTRIBUTING.md first. It covers setup and the PR flow.',
+  },
+  {
+    id: 'review',
+    commitment: 4,
+    mode: 'review',
+    modeLabel: 'Review',
+    who: 'You can read code and give feedback, often more useful than writing more.',
+    action: 'Review an open pull request',
+    href: `${REPO}/pulls`,
+    note: 'Reviews are the scarcest thing in most open-source projects.',
+  },
+  {
+    id: 'sibling',
+    commitment: 4,
+    mode: 'project',
+    modeLabel: 'Other projects',
+    who: 'This repo is one of many. Another BetterGov project may fit you better.',
+    action: 'Browse all BetterGov projects',
+    href: '/projects',
+    note: 'Each project has its own repository and its own open issues.',
+  },
+  {
+    id: 'register',
+    commitment: 5,
+    mode: 'project',
+    modeLabel: 'Your project',
+    who: 'You are building your own civic tech project and want it listed here.',
+    action: 'Ask about listing your project',
+    // Deliberately routes to a human: the registry (public/api/projects.json,
+    // repoType: "community") is real and schema-enforced, but the submission
+    // path is undocumented. Pointing at /projects would be a dead end — it
+    // lists projects but never says how to get listed.
+    href: '/discord',
+    alt: {
+      action: 'or email the volunteers',
+      href: 'mailto:volunteers@bettergov.ph',
+    },
+    note: 'Community projects are listed alongside the official ones.',
+  },
+];
+
+export interface Intro {
+  eyebrow: string;
+  heading: string;
+  standfirst: string;
+}
+
+/**
+ * The list's own framing. It must not restate the hero headline above it, and
+ * it carries full context because this page can be arrived at cold from a
+ * search engine rather than from the pages that would otherwise explain it.
+ */
+export const INTRO: Intro = {
+  eyebrow: 'Ways to help',
+  heading: 'Every way in, easiest first',
+  standfirst:
+    'BetterGov.ph is a volunteer-led, open-source civic tech project. Pick the first one that sounds like you. Nothing here needs permission to start.',
+};

--- a/src/pages/contribute/entryPoints.ts
+++ b/src/pages/contribute/entryPoints.ts
@@ -1,20 +1,6 @@
-/**
- * The entry-point index behind /contribute.
- *
- * Contributing to BetterGov is not contributing to one repository. Every
- * destination below already exists somewhere on this site or on GitHub; what
- * did not exist was a single place that routes between them. This page is an
- * index, not a new surface, so it duplicates no CTA and asserts no priority.
- *
- * Two rules keep it evergreen, which matters because it has no dedicated
- * owner:
- *
- *   1. Ordering is by COMMITMENT, lowest first. Ranking by "what the project
- *      needs most" would need a curator and would rot the moment nobody
- *      curates it.
- *   2. No counts, no dates, no live data. A link cannot go stale the way a
- *      rendered issue count can.
- */
+// Every destination here already exists elsewhere on the site or on GitHub.
+// Ordered by commitment, lowest first, and deliberately free of counts, dates
+// and live data so the list cannot go stale.
 
 export type Mode =
   | 'community'
@@ -24,7 +10,7 @@ export type Mode =
   | 'review'
   | 'project';
 
-/** How a destination must be rendered. Derived from the href so it cannot drift. */
+// Derived from the href so an entry point cannot mislabel its own destination.
 export type LinkKind = 'internal' | 'external' | 'email';
 
 export const linkKind = (href: string): LinkKind => {
@@ -39,20 +25,13 @@ export interface EntryPointAction {
 
 export interface EntryPoint extends EntryPointAction {
   id: string;
-  /** Ascending commitment. Drives display order. */
+  // Ascending commitment, which is also the display order.
   commitment: 1 | 2 | 3 | 4 | 5;
   mode: Mode;
   modeLabel: string;
-  /** "Is this you?" is the router's actual job. */
   who: string;
-  /**
-   * Second channel for the same job. Reporting and ideas both accept GitHub or
-   * Discord, because forcing a GitHub account on someone who only wants to say
-   * "this number is wrong" loses the report. The primary is the channel that
-   * leaves a durable record; the alternate is the lower-friction one.
-   */
+  // Lower-friction second channel, for people without a GitHub account.
   alt?: EntryPointAction;
-  /** Small muted note. Must be evergreen: no counts, no dates. */
   note?: string;
 }
 
@@ -148,10 +127,7 @@ export const ENTRY_POINTS: EntryPoint[] = [
     modeLabel: 'Your project',
     who: 'You are building your own civic tech project and want it listed here.',
     action: 'Ask about listing your project',
-    // Deliberately routes to a human: the registry (public/api/projects.json,
-    // repoType: "community") is real and schema-enforced, but the submission
-    // path is undocumented. Pointing at /projects would be a dead end — it
-    // lists projects but never says how to get listed.
+    // Routes to a human because the registry submission path is undocumented.
     href: '/discord',
     alt: {
       action: 'or email the volunteers',
@@ -167,11 +143,6 @@ export interface Intro {
   standfirst: string;
 }
 
-/**
- * The list's own framing. It must not restate the hero headline above it, and
- * it carries full context because this page can be arrived at cold from a
- * search engine rather than from the pages that would otherwise explain it.
- */
 export const INTRO: Intro = {
   eyebrow: 'Ways to help',
   heading: 'Every way in, easiest first',

--- a/src/pages/contribute/index.tsx
+++ b/src/pages/contribute/index.tsx
@@ -1,0 +1,46 @@
+import { FC } from 'react';
+import SEO from '../../components/SEO';
+import { ContributeHero } from './ContributeHero';
+import { ContributeRouter } from './ContributeRouter';
+
+/**
+ * /contribute — the index of every way into BetterGov.
+ *
+ * It sits beside /join-us rather than replacing it, because the two do
+ * different jobs: /join-us turns a stranger into someone interested,
+ * /contribute turns someone interested into a first contribution.
+ *
+ * Origin: issue #54, section 3.
+ */
+const Contribute: FC = () => (
+  <div className='min-h-screen bg-gray-50'>
+    {/* Title and description come from src/data/seo-metadata.json, keyed by
+        pathname. Passing them here too would be a second copy free to drift. */}
+    <SEO
+      keywords={[
+        'contribute',
+        'volunteer',
+        'open source',
+        'civic tech',
+        'bettergov',
+        'philippines',
+      ]}
+      breadcrumbs={[
+        { name: 'Home', url: '/' },
+        { name: 'Contribute', url: '/contribute' },
+      ]}
+    />
+
+    <ContributeHero />
+
+    <section
+      id='ways-to-help'
+      aria-labelledby='ways-to-help-heading'
+      className='py-12 md:py-16 scroll-mt-4'
+    >
+      <ContributeRouter />
+    </section>
+  </div>
+);
+
+export default Contribute;

--- a/src/pages/contribute/index.tsx
+++ b/src/pages/contribute/index.tsx
@@ -3,19 +3,11 @@ import SEO from '../../components/SEO';
 import { ContributeHero } from './ContributeHero';
 import { ContributeRouter } from './ContributeRouter';
 
-/**
- * /contribute — the index of every way into BetterGov.
- *
- * It sits beside /join-us rather than replacing it, because the two do
- * different jobs: /join-us turns a stranger into someone interested,
- * /contribute turns someone interested into a first contribution.
- *
- * Origin: issue #54, section 3.
- */
+// Sits beside /join-us rather than replacing it: /join-us introduces the
+// project, /contribute routes someone already interested to a first task.
 const Contribute: FC = () => (
   <div className='min-h-screen bg-gray-50'>
-    {/* Title and description come from src/data/seo-metadata.json, keyed by
-        pathname. Passing them here too would be a second copy free to drift. */}
+    {/* Title and description come from src/data/seo-metadata.json */}
     <SEO
       keywords={[
         'contribute',

--- a/src/pages/sitemap/index.tsx
+++ b/src/pages/sitemap/index.tsx
@@ -31,6 +31,11 @@ const SitemapPage: FC = () => {
         { title: 'Home', url: '/', description: 'Main landing page' },
         { title: 'About', url: '/about', description: 'About BetterGov.ph' },
         {
+          title: 'Contribute',
+          url: '/contribute',
+          description: 'Every way to help, ordered from easiest to hardest',
+        },
+        {
           title: 'Accessibility',
           url: '/accessibility',
           description: 'Accessibility statement and features',


### PR DESCRIPTION
# What type of PR is this?

- [ ] Bug
- [ ] Change
- [x] Feature
- [ ] Miscellaneous

---

## What you changed and why?

- Adds a new `/contribute` page: a single index of every existing way to contribute, ordered by commitment (lowest first), so a newcomer can find their entry point in under a minute.
- Every destination on the page already exists. Nothing new is introduced and no existing page changes. The gap this fills is routing: the answer to "what is the best way to help right now?" is currently spread across the Discord, the issue templates, `src/data`, the PR list, `/ideas`, `/projects` and the README, and none of those route to each other.
- Nine rows, each one "is this you? -> here is the one link": join the Discord, email the volunteers, report a bug, share an idea, fix data, take a good first issue, review an open PR, browse sibling BetterGov projects, or ask about listing your own project.
- Reporting and ideas each offer a second, lower-friction channel (Discord), because requiring a GitHub account from someone who only wants to say "this number is wrong" loses the report.
- Deliberately link-only. No issue counts, no embedded lists, no live data, so nothing on the page can go stale or render empty.
- Navigation: a "Contribute" link in the footer's About column, an entry on the `/sitemap` page, and a `/contribute` URL in the generated `sitemap.xml`.
- Tests cover the ordering invariant, unique ids, link classification, and that the rendered page links every entry point with the right target behaviour.

---

## Please specify which issue this PR Resolves (if applicable)

Relates to #54, section 3, which proposed exactly this page:

> Create an interactive contributing page on the BetterGov.ph website that serves as the main hub for potential contributors

Sections 1 and 2 of that issue shipped (#134, #235, #257). Section 3 was never built and never discussed. The issue was auto-closed `NOT_PLANNED` by the stale bot on 2025-12-03, so this is not a new proposal, it is the part that was left. Not using `Closes` since the issue is already closed and only one of its sections is addressed here.

Three deliberate divergences from that spec, each for a reason:

| #54 asked for | This PR | Why |
| --- | --- | --- |
| "Current Priorities, live-updated from GitHub" | Dropped | The `high`/`mid`/`low priority` labels all sit at 0 open issues. A priorities list needs a curator and goes stale without one. |
| "Recognition Wall" of contributors | Not included | The README already carries the contributors graph. |
| Issues embedded, filtered by `good first issue` | Linked, not embedded | An embed can render empty. A link cannot be wrong. |

Route named `/contribute` rather than `/contributing` to keep it distinct from `CONTRIBUTING.md` and `docs.bettergov.ph/docs/contributing`, which are dev-setup guides rather than a router. Happy to rename if you prefer.

---

## Checklist

- [x] I have performed a self-review of my own code.
- [x] These changes are now ready for review, or will be marked as draft.
- [x] This contribution was assisted by an AI agent. (if yes, please specify what agent is used under notes)

---

## Notes

**Screenshots:**

<img width="700" alt="The /contribute page above the fold: brand hero, Discord panel, and the top of the entry-point list" src="https://github.com/user-attachments/assets/8f0dbc60-03bc-4c8a-856a-9f8ef9159764" />

<details>
<summary>Full page</summary>

<img width="700" alt="The full /contribute page: hero, all nine entry points ordered by commitment, and the site footer" src="https://github.com/user-attachments/assets/95450891-e8af-4ab4-a1ac-48554019f51d" />

</details>


**One question I could not answer myself:** which Discord invite is canonical? Four are currently in circulation across BetterGov surfaces: `discord.gg/mHtThpN8bT` (`JoinUs.tsx` and two other places), `discord.gg/bettergovph` (the `/discord` redirect), `discord.gg/bettergov` (a `contact:` field), and `discord.gg/bettergovph` again on `about.bettergov.ph`. This page routes to the internal `/discord` redirect in five places, so it inherits whichever you pick. Worth settling once.

**Three things I noticed while building this, no action taken, no issues filed yet. Happy to send fixes if useful:**

1. `src/pages/Ideas.tsx:107` builds its prefilled issue URL with `template=idea-submission.md`, but the actual file is `.github/ISSUE_TEMPLATE/share-your-idea.md`. GitHub silently ignores an unknown template name and opens a blank issue, so the prefill has not been working. One-line fix.
2. `about.bettergov.ph/volunteer` ships two placeholder CTAs: "Volunteer Form" points at `https://forms.gle/example` and "Join Discord" at `https://discord.gg/example`. Different repo, so flagging rather than fixing.
3. `about.bettergov.ph/contribute` redirects to that volunteer page, so "contribute" resolves to different things on different subdomains. That page recruits by role (frontend, designer, researcher); this one routes by what you want to do today. They complement each other, but if the shared name bothers you, renaming this route is easy.

**On placement:** I also built a version that appended this content to the bottom of `/join-us`. It pushed the answer 5800px down the page, roughly 2.1x the height of a standalone page, so I ruled it out. `/join-us` introduces the project; this page routes someone who is already interested. Keeping them separate lets each do one job.

**Happy to help maintain this page.** It is built to be evergreen precisely because it should not need an owner: no counts, no dates, no data that can rot, and ordering by commitment rather than by project need, so it never needs re-curating.

---

## AI Disclosure

- This contribution was developed with the assistance of an AI coding tool: "Claude Code (Anthropic)".
