### PR TITLE
fix: deduplicate in-flight requests in fetchWithCache

### DIFF
--- a/src/lib/__tests__/api.test.ts
+++ b/src/lib/__tests__/api.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fetchWithCache } from '../api';
+
+describe('fetchWithCache', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('deduplicates concurrent requests to the same URL (in-flight sharing)', async () => {
+    let resolveResponse: (value: unknown) => void = () => {};
+    const responsePromise = new Promise(resolve => {
+      resolveResponse = resolve;
+    });
+
+    const fetchMock = vi.fn().mockReturnValue(responsePromise);
+    vi.stubGlobal('fetch', fetchMock);
+
+    // Two "components" request the same URL before the first response
+    // has arrived.
+    const call1 = fetchWithCache('https://api.bettergov.ph/weather');
+    const call2 = fetchWithCache('https://api.bettergov.ph/weather');
+
+    resolveResponse({
+      ok: true,
+      json: () => Promise.resolve({ temp: 30 }),
+    });
+
+    const [result1, result2] = await Promise.all([call1, call2]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(result1).toEqual({ temp: 30 });
+    expect(result2).toEqual({ temp: 30 });
+  });
+
+  it('makes a fresh request after the in-flight request settles', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ temp: 31 }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await fetchWithCache('https://api.bettergov.ph/forex', 0);
+    await fetchWithCache('https://api.bettergov.ph/forex', 0);
+
+    // cacheDuration is 0, so the second call should trigger a fresh
+    // request rather than reuse a stale in-flight/cache entry.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('serves from cache without hitting the network when still valid', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ temp: 32 }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const url = 'https://api.bettergov.ph/weather-cache-test';
+    await fetchWithCache(url, 60_000);
+    const cached = await fetchWithCache(url, 60_000);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(cached).toEqual({ temp: 32 });
+  });
+
+  it('clears the in-flight entry after a failed request, so a retry can fetch again', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 500 })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ temp: 33 }),
+      });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const url = 'https://api.bettergov.ph/weather-retry-test';
+
+    await expect(fetchWithCache(url)).rejects.toThrow(
+      'API request failed with status 500'
+    );
+
+    const result = await fetchWithCache(url);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ temp: 33 });
+  });
+});

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -8,6 +8,7 @@ type ApiCache = {
 
 const apiCache: ApiCache = {};
 
+const inFlightRequests: { [url: string]: Promise<unknown> } = {};
 /**
  * Fetch data from an API with caching
  * @param url The URL to fetch data from
@@ -25,20 +26,35 @@ export const fetchWithCache = async (
     return apiCache[url].data;
   }
 
-  // If no cache or expired, fetch new data
-  const response = await fetch(url);
-
-  if (!response.ok) {
-    throw new Error(`API request failed with status ${response.status}`);
+  // If a request for this URL is already in flight, reuse it instead of
+  // triggering a duplicate network request.
+  if (url in inFlightRequests) {
+    return inFlightRequests[url];
   }
+  const requestPromise = (async () => {
+    try {
+      // If no cache or expired, fetch new data
+      const response = await fetch(url);
 
-  const data = await response.json();
+      if (!response.ok) {
+        throw new Error(`API request failed with status ${response.status}`);
+      }
 
-  // Cache the new data
-  apiCache[url] = {
-    data,
-    timestamp: now,
-  };
+      const data = await response.json();
 
-  return data;
+      // Cache the new data
+      apiCache[url] = {
+        data,
+        timestamp: Date.now(),
+      };
+
+      return data;
+    } finally {
+      delete inFlightRequests[url];
+    }
+  })();
+
+  inFlightRequests[url] = requestPromise;
+
+  return requestPromise;
 };


### PR DESCRIPTION
Fixes #721

## Root Cause
`fetchWithCache` had no in-flight request tracking. When multiple 
components requested the same URL concurrently before the first 
response was cached (e.g. the weather and forex widgets both mounting 
on the home page), each call independently triggered its own network 
request — resulting in duplicate API calls.

## Fix
Added an in-flight promise map keyed by URL. Concurrent callers 
requesting the same URL now share a single in-progress request instead 
of firing duplicates. The tracking entry is cleared once the request 
settles (success or failure), so subsequent calls fetch fresh data as 
expected — no permanent caching of failures.

## Testing
Added 4 unit tests covering:
- Concurrent requests to the same URL are deduplicated (only 1 network call)
- A fresh request is made after the in-flight one settles
- Cache-hit path still avoids the network entirely
- After a failed request, a retry correctly triggers a fresh fetch

All tests pass, full suite green, typecheck and lint clean.
