### PR TITLE
fix(civic-assistant): make chat input text readable in dark mode

### DIFF
--- a/src/components/ui/CivicAssistant.tsx
+++ b/src/components/ui/CivicAssistant.tsx
@@ -130,7 +130,7 @@ const CivicAssistant: React.FC = () => {
                   ref={inputRef}
                   type='text'
                   placeholder='e.g. Passport, SSS, Housing...'
-                  className='w-full pl-4 pr-10 py-2.5 bg-gray-50 dark:bg-gray-800 border-none rounded-xl text-sm focus:ring-2 focus:ring-primary-500 transition-all outline-none'
+                  className='w-full pl-4 pr-10 py-2.5 bg-gray-50 dark:bg-gray-800 border-none rounded-xl text-sm text-gray-900 dark:text-white placeholder:text-gray-700 dark:placeholder:text-gray-400 focus:ring-2 focus:ring-primary-500 transition-all outline-none'
                   value={query}
                   onChange={e => handleSearch(e.target.value)}
                   disabled={isInitializing}


### PR DESCRIPTION
## Problem

The Civic Assistant search input has no text color class, so it inherits `rgb(0, 0, 0)` from the document body. Against the dark input background (`dark:bg-gray-800`, `#343a40`) that works out to a contrast ratio of **1.83:1**, which leaves typed text almost unreadable when the OS is set to dark mode.

`CivicAssistant.tsx` is currently the only file in `src/` that uses `dark:` variants, so the panel switches to its dark styling from `prefers-color-scheme` while the rest of the site stays light. That makes this input easy to miss.

Every other text element inside the panel already pairs a light color with a `dark:` variant and measures between 7.16:1 and 10.32:1. The input was the only one missing that pair.

## Fix

Add explicit text and placeholder colors for both color schemes on the input, following the convention already used elsewhere in this file (for example `text-gray-700 dark:text-gray-300` on the greeting bubble).

One note on the placeholder value: the gray scale defined in `src/index.css` is lighter than the Tailwind default, so `gray-500` reaches only 1.97:1 against the `gray-50` light background. `gray-700` is used for the light placeholder instead.

## Measured contrast

Values read with `getComputedStyle` in the running dev server at both `prefers-color-scheme` settings.

| | before | after |
|---|---|---|
| dark mode, input text | 1.83:1 (fail) | **11.51:1** |
| dark mode, placeholder | 1.47:1 (fail) | **7.70:1** |
| light mode, input text | 19.92:1 | 14.63:1 |
| light mode, placeholder | 3.92:1 (fail) | **7.76:1** |

Three of the four combinations failed WCAG AA for normal text (4.5:1) before this change. All four pass now.

Light mode input text moves from 19.92:1 to 14.63:1 because it goes from inherited pure black to the `gray-900` design token. That is a deliberate trade to keep the component self contained instead of depending on the inherited body color, and it stays far above the AA threshold.

## Testing

- `npm run lint` passes
- `npm run test:unit` passes (10 tests, 3 files)
- Verified visually in the dev server in both light and dark mode

`tsc` reports errors in `src/pages/travel/visa-types/[type].tsx`, but those are pre existing on `main` and unrelated to this change (identical output with and without this commit).

## AI assisted work disclosure

Per CONTRIBUTING.md: this change was made with AI assistance (Claude Code). The diff is a single line of Tailwind classes, and the contrast numbers above were measured in a browser rather than estimated.
