### PR TITLE
fix(flood-control): escape user input in Meilisearch filter expressions

### DIFF
--- a/src/pages/flood-control-projects/__tests__/utils.test.ts
+++ b/src/pages/flood-control-projects/__tests__/utils.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildEqualityFilter,
+  buildFilterString,
+  escapeFilterValue,
+  FilterState,
+} from '../utils';
+
+const emptyFilters = (): FilterState => ({
+  InfraYear: '',
+  Region: '',
+  Province: '',
+  TypeofWork: '',
+  DistrictEngineeringOffice: '',
+  LegislativeDistrict: '',
+});
+
+describe('escapeFilterValue', () => {
+  it('leaves ordinary values untouched', () => {
+    expect(escapeFilterValue('Region I')).toBe('Region I');
+  });
+
+  it('keeps apostrophes as-is, since the value is double quoted', () => {
+    expect(escapeFilterValue("DEV'T CORPORATION")).toBe("DEV'T CORPORATION");
+  });
+
+  it('escapes double quotes', () => {
+    expect(escapeFilterValue('a"b')).toBe('a\\"b');
+  });
+
+  it('escapes backslashes before quotes so the escape cannot be undone', () => {
+    expect(escapeFilterValue('a\\"b')).toBe('a\\\\\\"b');
+  });
+});
+
+describe('buildEqualityFilter', () => {
+  it('quotes and escapes the value', () => {
+    expect(buildEqualityFilter('Region', 'Region I')).toBe(
+      'Region = "Region I"'
+    );
+    expect(buildEqualityFilter('Region', 'a"b')).toBe('Region = "a\\"b"');
+  });
+});
+
+describe('buildFilterString', () => {
+  it('always pins the document type', () => {
+    expect(buildFilterString(emptyFilters())).toBe('type = "flood_control"');
+  });
+
+  it('builds a normal filter', () => {
+    expect(buildFilterString({ ...emptyFilters(), Region: 'Region I' })).toBe(
+      'type = "flood_control" AND Region = "Region I"'
+    );
+  });
+
+  it('accepts a valid year', () => {
+    expect(buildFilterString({ ...emptyFilters(), InfraYear: '2020' })).toBe(
+      'type = "flood_control" AND FundingYear = 2020'
+    );
+  });
+
+  // Each case below is a payload that escaped the filter expression before
+  // this was fixed. The type pin must survive all of them.
+  describe('filter injection via URL query parameters', () => {
+    it('neutralises a quoted-field breakout that ORs in another type', () => {
+      const filter = buildFilterString({
+        ...emptyFilters(),
+        Region: 'Region I" OR type = "internal_audit',
+      });
+      expect(filter).toBe(
+        'type = "flood_control" AND Region = "Region I\\" OR type = \\"internal_audit"'
+      );
+      // The injected OR is now inside the quoted value, not filter syntax.
+      expect(filter.startsWith('type = "flood_control" AND')).toBe(true);
+    });
+
+    it('drops a non-numeric year instead of interpolating it unquoted', () => {
+      expect(
+        buildFilterString({
+          ...emptyFilters(),
+          InfraYear: '2020 OR type = "internal_audit"',
+        })
+      ).toBe('type = "flood_control"');
+    });
+
+    it('rejects a year that is not exactly four digits', () => {
+      for (const bad of ['20', '20200', 'abcd', '2020;', ' 2020 OR 1=1']) {
+        expect(buildFilterString({ ...emptyFilters(), InfraYear: bad })).toBe(
+          'type = "flood_control"'
+        );
+      }
+    });
+
+    it('neutralises an AND-based result suppression payload', () => {
+      const filter = buildFilterString({
+        ...emptyFilters(),
+        Region: 'Region I" AND type = "nonexistent',
+      });
+      expect(filter).toBe(
+        'type = "flood_control" AND Region = "Region I\\" AND type = \\"nonexistent"'
+      );
+    });
+
+    it('escapes payloads aimed at every string-valued field', () => {
+      const payload = 'x" OR type = "internal_audit';
+      const filter = buildFilterString({
+        InfraYear: '',
+        Region: payload,
+        Province: payload,
+        TypeofWork: payload,
+        DistrictEngineeringOffice: payload,
+        LegislativeDistrict: payload,
+      });
+      // No unescaped quote may appear anywhere except around the values.
+      expect(filter).not.toMatch(/[^\\]" OR type/);
+    });
+  });
+});

--- a/src/pages/flood-control-projects/contractors.tsx
+++ b/src/pages/flood-control-projects/contractors.tsx
@@ -26,6 +26,7 @@ import { ScrollArea } from '../../components/ui/ScrollArea';
 // Import contractor data
 import contractorData from '../../data/flood_control/lookups/Contractor_with_counts.json';
 import FloodControlProjectsTab from './tab';
+import { buildEqualityFilter } from './utils';
 
 // Define types for our data
 interface DataItem {
@@ -564,7 +565,7 @@ const FloodControlProjectsContractors: FC = () => {
 
     // Add contractor filter if one is selected
     if (selectedContractor) {
-      filters.push(`Contractor = "${selectedContractor}"`);
+      filters.push(buildEqualityFilter('Contractor', selectedContractor));
     }
 
     return filters.join(' AND ');

--- a/src/pages/flood-control-projects/contractors/[contractor-name].tsx
+++ b/src/pages/flood-control-projects/contractors/[contractor-name].tsx
@@ -23,6 +23,7 @@ import 'leaflet/dist/leaflet.css';
 // Import contractor data
 import contractorData from '../../../data/flood_control/lookups/Contractor_with_counts.json';
 import FloodControlProjectsTab from '../tab';
+import { buildEqualityFilter } from '../utils';
 
 // Define types for our data
 interface DataItem {
@@ -591,7 +592,7 @@ const ContractorDetail: FC = () => {
 
     // Add contractor filter if contractor is available
     if (contractor) {
-      filters.push(`Contractor = "${contractor.value}"`);
+      filters.push(buildEqualityFilter('Contractor', contractor.value));
     }
 
     return filters.join(' AND ');
@@ -842,7 +843,7 @@ const ContractorDetail: FC = () => {
           >
             <Configure
               hitsPerPage={1}
-              filters={`slug = "${contractorSlug}"`}
+              filters={buildEqualityFilter('slug', contractorSlug)}
               query=''
             />
             <ContractorProfileFetcher onProfileUpdate={setContractorProfile} />

--- a/src/pages/flood-control-projects/table.tsx
+++ b/src/pages/flood-control-projects/table.tsx
@@ -25,7 +25,7 @@ import deoData from '../../data/flood_control/lookups/DistrictEngineeringOffice_
 import legislativeDistrictData from '../../data/flood_control/lookups/LegislativeDistrict_with_counts.json';
 import typeOfWorkData from '../../data/flood_control/lookups/TypeofWork_with_counts.json';
 import { useSearchParams } from 'react-router-dom';
-import { generateUrlParams } from './utils';
+import { buildFilterString, generateUrlParams } from './utils';
 
 // Define types for our data
 interface DataItem {
@@ -652,53 +652,6 @@ const FloodControlProjectsTable: FC = () => {
     setSearchParams(generateUrlParams(newFilters));
   };
 
-  // Build filter string for Meilisearch
-  const buildFilterString = (): string => {
-    // Start with an empty array - we'll add filters as needed
-    const filterStrings: string[] = [];
-
-    // Based on the error message, these are the only filterable attributes:
-    // CompletionDateActual, DistrictEngineeringOffice, FundingYear, GlobalID,
-    // LegislativeDistrict, Municipality, Province, Region, StartDate, TypeofWork, type
-
-    // Always filter by type - format it correctly
-    filterStrings.push('type = "flood_control"');
-
-    // InfraYear is not filterable, try using FundingYear instead if they represent the same data
-    if (filters.InfraYear && filters.InfraYear.trim()) {
-      filterStrings.push(`FundingYear = ${filters.InfraYear.trim()}`);
-    }
-
-    if (filters.Region && filters.Region.trim()) {
-      filterStrings.push(`Region = "${filters.Region.trim()}"`);
-    }
-
-    if (filters.Province && filters.Province.trim()) {
-      filterStrings.push(`Province = "${filters.Province.trim()}"`);
-    }
-
-    if (filters.TypeofWork && filters.TypeofWork.trim()) {
-      filterStrings.push(`TypeofWork = "${filters.TypeofWork.trim()}"`);
-    }
-
-    if (
-      filters.DistrictEngineeringOffice &&
-      filters.DistrictEngineeringOffice.trim()
-    ) {
-      filterStrings.push(
-        `DistrictEngineeringOffice = "${filters.DistrictEngineeringOffice.trim()}"`
-      );
-    }
-
-    if (filters.LegislativeDistrict && filters.LegislativeDistrict.trim()) {
-      filterStrings.push(
-        `LegislativeDistrict = "${filters.LegislativeDistrict.trim()}"`
-      );
-    }
-
-    return filterStrings.length > 0 ? filterStrings.join(' AND ') : '';
-  };
-
   const provinceOptions = useMemo(() => {
     if (filters.Region === 'National Capital Region') {
       const nationalCapitalRegion = provinceData.Province.filter(
@@ -724,7 +677,7 @@ const FloodControlProjectsTable: FC = () => {
     setIsExporting(true);
 
     // Build filter string based on selected filters
-    const filterString = buildFilterString();
+    const filterString = buildFilterString(filters);
     // Get effective search term including year filter if present
     const effectiveSearchTerm = getEffectiveSearchTerm();
 
@@ -927,7 +880,7 @@ const FloodControlProjectsTable: FC = () => {
               >
                 <Configure
                   hitsPerPage={1000}
-                  filters={buildFilterString()}
+                  filters={buildFilterString(filters)}
                   query={getEffectiveSearchTerm()}
                 />
                 <TableHits filters={filters} searchTerm={searchTerm} />

--- a/src/pages/flood-control-projects/utils.ts
+++ b/src/pages/flood-control-projects/utils.ts
@@ -8,6 +8,24 @@ export type FilterState = {
   LegislativeDistrict: string;
 };
 
+/**
+ * Escapes a value before it is interpolated into a Meilisearch filter
+ * expression.
+ *
+ * Filter values reach us from URL query parameters, so a value containing a
+ * double quote would otherwise close the quoted string early and let the rest
+ * of the value be parsed as filter syntax. Backslashes are escaped first so
+ * that the ones added for quotes are not escaped a second time.
+ */
+export const escapeFilterValue = (value: string): string =>
+  value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+
+/**
+ * Builds a `field = "value"` equality term with the value safely escaped.
+ */
+export const buildEqualityFilter = (field: string, value: string): string =>
+  `${field} = "${escapeFilterValue(value)}"`;
+
 // Utility function to build filter string
 export const buildFilterString = (filters: FilterState): string => {
   // Start with an empty array - we'll add filters as needed
@@ -16,20 +34,28 @@ export const buildFilterString = (filters: FilterState): string => {
   // Always filter by type
   filterStrings.push('type = "flood_control"');
 
-  if (filters.InfraYear && filters.InfraYear.trim()) {
-    filterStrings.push(`FundingYear = ${filters.InfraYear.trim()}`);
+  // FundingYear is numeric, so it is compared unquoted. Only emit the term
+  // when the value really is a year, otherwise an arbitrary string would be
+  // interpolated straight into the expression as filter syntax.
+  const infraYear = filters.InfraYear?.trim();
+  if (infraYear && /^\d{4}$/.test(infraYear)) {
+    filterStrings.push(`FundingYear = ${infraYear}`);
   }
 
   if (filters.Region && filters.Region.trim()) {
-    filterStrings.push(`Region = "${filters.Region.trim()}"`);
+    filterStrings.push(buildEqualityFilter('Region', filters.Region.trim()));
   }
 
   if (filters.Province && filters.Province.trim()) {
-    filterStrings.push(`Province = "${filters.Province.trim()}"`);
+    filterStrings.push(
+      buildEqualityFilter('Province', filters.Province.trim())
+    );
   }
 
   if (filters.TypeofWork && filters.TypeofWork.trim()) {
-    filterStrings.push(`TypeofWork = "${filters.TypeofWork.trim()}"`);
+    filterStrings.push(
+      buildEqualityFilter('TypeofWork', filters.TypeofWork.trim())
+    );
   }
 
   if (
@@ -37,13 +63,19 @@ export const buildFilterString = (filters: FilterState): string => {
     filters.DistrictEngineeringOffice.trim()
   ) {
     filterStrings.push(
-      `DistrictEngineeringOffice = "${filters.DistrictEngineeringOffice.trim()}"`
+      buildEqualityFilter(
+        'DistrictEngineeringOffice',
+        filters.DistrictEngineeringOffice.trim()
+      )
     );
   }
 
   if (filters.LegislativeDistrict && filters.LegislativeDistrict.trim()) {
     filterStrings.push(
-      `LegislativeDistrict = "${filters.LegislativeDistrict.trim()}"`
+      buildEqualityFilter(
+        'LegislativeDistrict',
+        filters.LegislativeDistrict.trim()
+      )
     );
   }
 


### PR DESCRIPTION
## Problem

The flood control pages read six filter values straight out of the URL query string and interpolate them into Meilisearch filter expressions with no escaping.

`src/pages/flood-control-projects/index.tsx:452-457` reads `year`, `region`, `province`, `typeOfWork`, `deo` and `district` into state, and `utils.ts` `buildFilterString` interpolates them. `table.tsx:619-626` does the same through its own duplicated copy of that function.

A value containing a double quote closes the quoted string early, so the remainder is parsed as filter syntax. Every page pins its results with `type = "flood_control"`, and that pin can be escaped:

```
?region=Region I" OR type = "internal_audit
```

produces

```
type = "flood_control" AND Region = "Region I" OR type = "internal_audit"
```

`AND` binds tighter than `OR` in Meilisearch, so this evaluates as `(type = flood_control AND Region = "Region I") OR type = "internal_audit"` and returns documents the pin was meant to exclude.

`FundingYear` is compared unquoted, so it does not even need a quote:

```
?year=2020 OR type = "internal_audit"
```

## Impact

The search key shipped to the browser is a public search-only key, so this does not by itself expose anything an attacker could not already request from Meilisearch directly. The practical impact is reflected, through a link:

- **Result suppression.** `?region=Region I" AND type = "nonexistent` renders an empty result set. A link that looks like an ordinary filtered view of public infrastructure spending can be crafted to show nothing, or to show a different set than its parameters suggest.
- **Broken pages.** A malformed value such as `?region=");(` makes Meilisearch return HTTP 400 and the view renders empty.
- **Scope creep later.** The filter layer is what separates document types in a shared index today. If anything non public is ever added behind a filter, this becomes an access control bypass rather than a display problem.

I would call this medium severity rather than critical, and I would rather state that plainly than oversell it.

## Verification

Validated against a local Meilisearch 1.53.1 instance seeded with one `flood_control` document and one `internal_audit` document, driving the application's own `buildFilterString` rather than a reimplementation. No requests were made to production infrastructure.

Before:

| payload | generated filter | result |
|---|---|---|
| `?region=Region I` (baseline) | `type = "flood_control" AND Region = "Region I"` | 1 flood_control row |
| `?region=Region I" OR type = "internal_audit` | `... AND Region = "Region I" OR type = "internal_audit"` | **internal_audit row returned** |
| `?year=2020 OR type = "internal_audit"` | `... AND FundingYear = 2020 OR type = "internal_audit"` | **internal_audit row returned** |
| `?region=");(` | `... AND Region = "");("` | **HTTP 400** |

After: the baseline is unchanged, the two injection payloads return no rows with the type pin intact, and the malformed payload returns HTTP 200 with no rows instead of a 400.

## Changes

- Add `escapeFilterValue` and `buildEqualityFilter` to `utils.ts`. Backslashes are escaped before quotes so the escapes that get added cannot themselves be undone.
- Only emit `FundingYear` when the value is four digits. Every value in the `InfraYear` lookup is a four digit year, so no legitimate input is rejected.
- Delete the duplicated `buildFilterString` in `table.tsx` and use the shared one, so there is one implementation to keep correct instead of two.
- Apply the same escaping to the `Contractor` and `slug` filters in `contractors.tsx` and `contractors/[contractor-name].tsx`. Neither is reachable from the URL today, the slug is constrained by a whitelist lookup, so these are defence in depth rather than live fixes.

Apostrophes are deliberately left alone. 83 contractor names contain them and they are already safe inside a double quoted value.

## Testing

- 12 new tests in `src/pages/flood-control-projects/__tests__/utils.test.ts`, one per payload above plus escaping and year validation cases
- `npm run test:unit` passes, 23 tests across 4 files
- `npm run lint` passes
- `tsc` error count is unchanged against `main`, the pre existing errors in `src/pages/travel/visa-types/[type].tsx` are unrelated
- Both affected pages render correctly in the dev server with ordinary filters applied

## Note on other findings

This came out of a wider look at input handling. A few other things surfaced that are deliberately not in this PR, and I am happy to open separate issues or PRs:

- `functions/api/report-hotline.ts` has no rate limiting or length caps, and creates public GitHub issues on this repo from an unauthenticated POST
- the same file interpolates `reporterEmail` into an HTML comment, which a `-->` in the value escapes
- `functions/api/crawl.ts:255` calls `getContentByUrl` without importing it, so the cached read path throws
- `functions/api/crawl.ts:138` sets module level state from a query parameter, which leaks across requests in a Worker isolate
- `npm run functions:build` currently reports 27 type errors, which is why the two above are not caught

## AI assisted work disclosure

Per CONTRIBUTING.md: this change was made with AI assistance (Claude Code). The vulnerability was confirmed with a working proof of concept against a local Meilisearch instance before any code was changed, and the same proof of concept was re-run against the fix.
