### PR TITLE
fix: point TIN registration to ORUS home

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -44,6 +44,7 @@
     "joinMovement": "Join Our Movement",
     "or": "or",
     "joinDiscord": "Join Discord",
+    "findWayToContribute": "Find a Way to Contribute",
     "features": "🚀 Infrastructure • 💡 Mentorship • 🤝 Community • 🏢 Office Space"
   },
   "data": {

--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -278,6 +278,7 @@ function generateSiteUrls(mainNavigation, governmentData) {
   const mainPages = [
     { url: `${siteUrl}/`, priority: '1.0', changefreq: 'daily' },
     { url: `${siteUrl}/about`, priority: '0.8', changefreq: 'monthly' },
+    { url: `${siteUrl}/contribute`, priority: '0.7', changefreq: 'monthly' },
     { url: `${siteUrl}/search`, priority: '0.9', changefreq: 'weekly' },
     { url: `${siteUrl}/services`, priority: '0.9', changefreq: 'weekly' },
     { url: `${siteUrl}/sitemap`, priority: '0.5', changefreq: 'monthly' },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -92,6 +92,7 @@ import Discord from './pages/Discord';
 import SalaryGradePage from './pages/government/salary-grade/index';
 import CivicAssistant from './components/ui/CivicAssistant';
 import NotFound from './pages/NotFound';
+import Contribute from './pages/contribute';
 
 function App() {
   return (
@@ -113,6 +114,7 @@ function App() {
             <Route path='/search' element={<SearchPage />} />
             <Route path='/ideas' element={<Ideas />} />
             <Route path='/join-us' element={<JoinUs />} />
+            <Route path='/contribute' element={<Contribute />} />
             <Route path='/terms-of-service' element={<TermsOfService />} />
             <Route path='/sitemap' element={<SitemapPage />} />
             <Route path='/discord' Component={Discord} />

--- a/src/components/home/JoinUsBanner.tsx
+++ b/src/components/home/JoinUsBanner.tsx
@@ -1,8 +1,12 @@
-import { ArrowRightIcon, UsersIcon, ZapIcon } from 'lucide-react';
+import {
+  ArrowRightIcon,
+  LightbulbIcon,
+  UsersIcon,
+  ZapIcon,
+} from 'lucide-react';
 import { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
-import { SiDiscord } from '@icons-pack/react-simple-icons';
 
 const JoinUsBanner: FC = () => {
   const { t } = useTranslation('common');
@@ -53,15 +57,13 @@ const JoinUsBanner: FC = () => {
 
             <div className='text-orange-100 font-medium'>{t('joinUs.or')}</div>
 
-            <a
-              href='https://discord.gg/mHtThpN8bT'
-              target='_blank'
-              rel='noreferrer'
+            <Link
+              to='/contribute'
               className='inline-flex items-center justify-center px-6 py-3 border-2 border-white text-white font-semibold rounded-lg hover:bg-white hover:text-gray-900 transition-all'
             >
-              <SiDiscord className='h-5 w-5 mr-2' />
-              {t('joinUs.joinDiscord')}
-            </a>
+              <LightbulbIcon className='h-5 w-5 mr-2' />
+              {t('joinUs.findWayToContribute')}
+            </Link>
           </div>
 
           <div className='mt-8 pt-6 border-t border-white/20'>

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -172,6 +172,7 @@ export const footerNavigation = {
         { label: 'About the Portal', href: '/about' },
         { label: 'About BetterGov.ph', href: 'https://about.bettergov.ph' },
         { label: 'Documentation', href: 'https://docs.bettergov.ph/' },
+        { label: 'Contribute', href: '/contribute' },
         { label: 'Project Ideas', href: '/ideas' },
         { label: 'Accessibility', href: '/accessibility' },
         { label: 'Terms of Use', href: '/terms-of-service' },

--- a/src/data/seo-metadata.json
+++ b/src/data/seo-metadata.json
@@ -11,6 +11,10 @@
     "title": "Accessibility Statement | BetterGov.ph | BetterGov.ph",
     "description": "Find important information about Accessibility Statement through BetterGov.ph, the Philippines\u2019 civic information portal."
   },
+  "/contribute": {
+    "title": "Contribute | BetterGov.ph",
+    "description": "Every way to contribute to BetterGov.ph, ordered from easiest to hardest: join the Discord, report a problem, share an idea, fix data, write code, review pull requests, or list your own civic tech project."
+  },
   "/data/forex": {
     "title": "Forex: Currency Converter - BetterGov.ph",
     "description": "Find important information about Forex: Currency Converter through BetterGov.ph, the Philippines\u2019 civic information portal."

--- a/src/data/services/tax.json
+++ b/src/data/services/tax.json
@@ -55,7 +55,7 @@
   },
   {
     "service": "Register for a Taxpayer Identification Number (TIN)",
-    "url": "https://orus.bir.gov.ph/",
+    "url": "https://orus.bir.gov.ph/home",
     "id": "387e8805-4277-4a21-bf1b-116bea0586cb",
     "slug": "register-for-a-taxpayer-identification-number-tin",
     "published": true,

--- a/src/pages/JoinUs.tsx
+++ b/src/pages/JoinUs.tsx
@@ -15,6 +15,7 @@ import {
 import { SiDiscord } from '@icons-pack/react-simple-icons';
 import { FC } from 'react';
 import { Helmet } from 'react-helmet-async';
+import { Link } from 'react-router-dom';
 
 const JoinUs: FC = () => {
   return (
@@ -274,15 +275,13 @@ const JoinUs: FC = () => {
 
               <div className='text-white font-medium'>or</div>
 
-              <a
-                href='https://bettergov.ph/ideas'
-                target='_blank'
-                rel='noreferrer'
+              <Link
+                to='/contribute'
                 className='inline-flex items-center justify-center px-8 py-4 border-2 border-white text-white font-semibold rounded-lg hover:bg-white hover:text-primary-600 transition-all'
               >
                 <LightbulbIcon className='h-5 w-5 mr-2' />
-                Explore Project Ideas
-              </a>
+                Find a Way to Contribute
+              </Link>
             </div>
 
             <div className='mt-8 pt-6 border-t border-white/20'>

--- a/src/pages/contribute/ContributeHero.tsx
+++ b/src/pages/contribute/ContributeHero.tsx
@@ -1,0 +1,55 @@
+import { SiDiscord } from '@icons-pack/react-simple-icons';
+import { FC } from 'react';
+import { Link } from 'react-router-dom';
+
+const MODES = ['Join in', 'Fix data', 'Write code', 'Build your own'];
+
+export const ContributeHero: FC = () => (
+  <section className='bg-linear-to-r from-primary-600 to-primary-700 text-white'>
+    {/* max-w-4xl to line the hero up with the list below it */}
+    <div className='container mx-auto px-4 max-w-4xl py-12 md:py-20'>
+      <div className='grid grid-cols-1 lg:grid-cols-2 gap-8 items-center'>
+        <div className='animate-fade-in'>
+          <h1 className='text-3xl md:text-4xl lg:text-5xl font-bold mb-4 leading-tight'>
+            Contribute to BetterGov.ph
+          </h1>
+          <p className='text-lg text-blue-100 mb-6 max-w-lg'>
+            Volunteer-led. Open source. Community-driven. Every current way in
+            is on this page, ordered by how much it asks of you.
+          </p>
+          <ul className='flex flex-wrap gap-2 list-none p-0 m-0'>
+            {MODES.map(mode => (
+              <li
+                key={mode}
+                className='bg-white/10 text-white border border-white/20 py-2 px-4 rounded-xl text-sm'
+              >
+                {mode}
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <div className='bg-white/10 backdrop-blur-xs rounded-xl p-6 shadow-lg animate-slide-in'>
+          <h2 className='text-2xl font-semibold mb-2'>
+            Not sure where to fit?
+          </h2>
+          <p className='text-blue-100 mb-5'>
+            Start in the Discord. It costs nothing, needs no technical skill,
+            and everything else on this page starts there anyway.
+          </p>
+          <Link
+            to='/discord'
+            className='inline-flex items-center justify-center w-full px-6 py-3 bg-yellow-400 text-gray-900 font-bold rounded-lg hover:bg-yellow-300 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white transition-all'
+          >
+            <SiDiscord className='h-5 w-5 mr-2' aria-hidden='true' />
+            Start in the Discord
+          </Link>
+          <p className='text-blue-100 text-sm mt-4'>
+            Already know what you want to do? The list below is ordered easiest
+            first.
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+);

--- a/src/pages/contribute/ContributeRouter.tsx
+++ b/src/pages/contribute/ContributeRouter.tsx
@@ -1,0 +1,121 @@
+import { ArrowRightIcon, ExternalLinkIcon, MailIcon } from 'lucide-react';
+import { FC } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  ENTRY_POINTS,
+  EntryPoint,
+  EntryPointAction,
+  INTRO,
+  linkKind,
+} from './entryPoints';
+
+const COMMITMENT_LABEL: Record<EntryPoint['commitment'], string> = {
+  1: 'Minutes',
+  2: 'Minutes',
+  3: 'An hour',
+  4: 'An evening',
+  5: 'Ongoing',
+};
+
+// Rows carry up to two actions, so the row itself cannot be one big link.
+const Action: FC<EntryPointAction & { primary?: boolean }> = ({
+  action,
+  href,
+  primary = false,
+}) => {
+  const kind = linkKind(href);
+
+  const className = primary
+    ? 'group inline-flex items-center gap-1.5 text-primary-600 font-semibold hover:gap-2.5 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 rounded-xs transition-all'
+    : 'inline-flex items-center text-sm text-gray-500 hover:text-primary-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600 rounded-xs underline underline-offset-2';
+
+  const Icon =
+    kind === 'external'
+      ? ExternalLinkIcon
+      : kind === 'email'
+        ? MailIcon
+        : ArrowRightIcon;
+
+  const icon = primary && <Icon className='h-4 w-4' aria-hidden='true' />;
+
+  if (kind === 'internal') {
+    return (
+      <Link to={href} className={className}>
+        {action}
+        {icon}
+      </Link>
+    );
+  }
+
+  // mailto: hands off to a mail client, so a new tab would leave a blank one behind.
+  const newTab = kind === 'external';
+
+  return (
+    <a
+      href={href}
+      className={className}
+      {...(newTab ? { target: '_blank', rel: 'noreferrer' } : {})}
+    >
+      {action}
+      {/* New tab warning for screen readers */}
+      {newTab && <span className='sr-only'> (opens in a new tab)</span>}
+      {icon}
+    </a>
+  );
+};
+
+const Row: FC<{ entry: EntryPoint }> = ({ entry }) => (
+  <li className='flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-6 p-5 bg-white border border-gray-200 rounded-xl hover:border-primary-400 hover:shadow-sm transition-all'>
+    <div className='flex-1'>
+      <div className='flex items-center gap-2 mb-1'>
+        <h3 className='text-xs font-semibold uppercase tracking-wide text-primary-600'>
+          {entry.modeLabel}
+        </h3>
+        <span className='text-xs text-gray-400'>
+          · {COMMITMENT_LABEL[entry.commitment]}
+        </span>
+      </div>
+      <p className='text-gray-900 font-medium leading-snug'>{entry.who}</p>
+      {entry.note && <p className='text-sm text-gray-500 mt-1'>{entry.note}</p>}
+    </div>
+
+    <div className='shrink-0 flex flex-col sm:items-end gap-1'>
+      <Action action={entry.action} href={entry.href} primary />
+      {entry.alt && <Action action={entry.alt.action} href={entry.alt.href} />}
+    </div>
+  </li>
+);
+
+export const ContributeRouter: FC = () => (
+  <div className='container mx-auto px-4 max-w-4xl'>
+    <div className='mb-8'>
+      <p className='text-sm font-bold uppercase tracking-wider text-primary-600 mb-2'>
+        {INTRO.eyebrow}
+      </p>
+      <h2
+        id='ways-to-help-heading'
+        className='text-3xl md:text-4xl font-bold text-gray-900 mb-3'
+      >
+        {INTRO.heading}
+      </h2>
+      <p className='text-lg text-gray-600 max-w-2xl'>{INTRO.standfirst}</p>
+    </div>
+
+    <ul
+      aria-label='Ways to contribute'
+      className='flex flex-col gap-3 list-none p-0 m-0'
+    >
+      {ENTRY_POINTS.map(entry => (
+        <Row key={entry.id} entry={entry} />
+      ))}
+    </ul>
+
+    <p className='text-sm text-gray-500 mt-8'>
+      Not sure which one fits? Ask in the{' '}
+      <Link to='/discord' className='text-primary-600 underline'>
+        Discord
+      </Link>
+      .
+    </p>
+  </div>
+);

--- a/src/pages/contribute/__tests__/Contribute.test.tsx
+++ b/src/pages/contribute/__tests__/Contribute.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen, within } from '@testing-library/react';
+import { HelmetProvider } from 'react-helmet-async';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import Contribute from '..';
+import { ENTRY_POINTS } from '../entryPoints';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: { language: 'en', resolvedLanguage: 'en' },
+  }),
+}));
+
+const renderPage = () =>
+  render(
+    <HelmetProvider>
+      <MemoryRouter initialEntries={['/contribute']}>
+        <Contribute />
+      </MemoryRouter>
+    </HelmetProvider>
+  );
+
+describe('Contribute', () => {
+  it('names the page once, in the hero', () => {
+    renderPage();
+
+    expect(
+      screen.getByRole('heading', {
+        level: 1,
+        name: /contribute to bettergov/i,
+      })
+    ).toBeInTheDocument();
+  });
+
+  // Off-site actions append an sr-only new-tab warning to their name.
+  const linkFor = (action: string) =>
+    screen.getByRole('link', { name: name => name.startsWith(action) });
+
+  it('renders every entry point as its own action', () => {
+    renderPage();
+
+    for (const entry of ENTRY_POINTS) {
+      expect(linkFor(entry.action), entry.id).toBeInTheDocument();
+    }
+  });
+
+  it('lists the entry points in commitment order', () => {
+    renderPage();
+
+    const list = screen.getByRole('list', { name: /ways to contribute/i });
+    const rendered = within(list)
+      .getAllByRole('listitem')
+      .map(item => within(item).getByRole('heading').textContent);
+
+    expect(rendered).toEqual(ENTRY_POINTS.map(entry => entry.modeLabel));
+  });
+
+  it('opens off-site destinations in a new tab, and site pages in place', () => {
+    renderPage();
+
+    const offSite = linkFor('Review an open pull request');
+
+    expect(offSite).toHaveAttribute('target', '_blank');
+    expect(offSite).toHaveAccessibleName(/opens in a new tab/i);
+    expect(linkFor('Join the Discord')).toHaveAttribute('href', '/discord');
+  });
+
+  it('links the volunteers address as a mail client handoff, not a new tab', () => {
+    renderPage();
+
+    const email = linkFor('Email the volunteers');
+
+    expect(email).toHaveAttribute('href', 'mailto:volunteers@bettergov.ph');
+    expect(email).not.toHaveAttribute('target');
+  });
+});

--- a/src/pages/contribute/__tests__/entryPoints.test.ts
+++ b/src/pages/contribute/__tests__/entryPoints.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { ENTRY_POINTS, INTRO, linkKind } from '../entryPoints';
+
+describe('linkKind', () => {
+  it('classifies a site-relative path as internal', () => {
+    expect(linkKind('/discord')).toBe('internal');
+  });
+
+  it('classifies a mailto: href as email', () => {
+    expect(linkKind('mailto:volunteers@bettergov.ph')).toBe('email');
+  });
+
+  it('classifies an absolute URL as external', () => {
+    expect(linkKind('https://github.com/bettergovph/bettergov')).toBe(
+      'external'
+    );
+  });
+});
+
+describe('ENTRY_POINTS', () => {
+  it('is ordered by commitment, lowest first', () => {
+    const commitments = ENTRY_POINTS.map(entry => entry.commitment);
+
+    expect(commitments).toEqual([...commitments].sort((a, b) => a - b));
+  });
+
+  it('has a unique id per entry', () => {
+    const ids = ENTRY_POINTS.map(entry => entry.id);
+
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('routes every action somewhere resolvable', () => {
+    for (const entry of ENTRY_POINTS) {
+      expect(linkKind(entry.href), entry.id).toBeDefined();
+      if (entry.alt) expect(linkKind(entry.alt.href), entry.id).toBeDefined();
+    }
+  });
+
+  it('offers the volunteers mailing address as its own entry point', () => {
+    const email = ENTRY_POINTS.find(
+      entry => entry.href === 'mailto:volunteers@bettergov.ph'
+    );
+
+    expect(email).toBeDefined();
+  });
+
+  it('carries no em dashes in copy the reader sees', () => {
+    const copy = [
+      INTRO.eyebrow,
+      INTRO.heading,
+      INTRO.standfirst,
+      ...ENTRY_POINTS.flatMap(entry => [
+        entry.modeLabel,
+        entry.who,
+        entry.action,
+        entry.note ?? '',
+        entry.alt?.action ?? '',
+      ]),
+    ].join(' ');
+
+    expect(copy).not.toContain('—');
+  });
+});

--- a/src/pages/contribute/entryPoints.ts
+++ b/src/pages/contribute/entryPoints.ts
@@ -1,0 +1,151 @@
+// Every destination here already exists elsewhere on the site or on GitHub.
+// Ordered by commitment, lowest first, and deliberately free of counts, dates
+// and live data so the list cannot go stale.
+
+export type Mode =
+  | 'community'
+  | 'report'
+  | 'ideas'
+  | 'code'
+  | 'review'
+  | 'project';
+
+// Derived from the href so an entry point cannot mislabel its own destination.
+export type LinkKind = 'internal' | 'external' | 'email';
+
+export const linkKind = (href: string): LinkKind => {
+  if (href.startsWith('mailto:')) return 'email';
+  return href.startsWith('/') ? 'internal' : 'external';
+};
+
+export interface EntryPointAction {
+  action: string;
+  href: string;
+}
+
+export interface EntryPoint extends EntryPointAction {
+  id: string;
+  // Ascending commitment, which is also the display order.
+  commitment: 1 | 2 | 3 | 4 | 5;
+  mode: Mode;
+  modeLabel: string;
+  who: string;
+  // Lower-friction second channel, for people without a GitHub account.
+  alt?: EntryPointAction;
+  note?: string;
+}
+
+const REPO = 'https://github.com/bettergovph/bettergov';
+
+export const ENTRY_POINTS: EntryPoint[] = [
+  {
+    id: 'discord',
+    commitment: 1,
+    mode: 'community',
+    modeLabel: 'Community',
+    who: 'You want to see what people are working on before committing to anything.',
+    action: 'Join the Discord',
+    href: '/discord',
+    note: 'Everything else starts here. No technical skill needed.',
+  },
+  {
+    id: 'email',
+    commitment: 1,
+    mode: 'community',
+    modeLabel: 'Email',
+    who: 'You would rather write to a person than join a chat server.',
+    action: 'Email the volunteers',
+    href: 'mailto:volunteers@bettergov.ph',
+    note: 'Goes to the volunteer team. Good for offers of help that do not fit a form.',
+  },
+  {
+    id: 'report',
+    commitment: 2,
+    mode: 'report',
+    modeLabel: 'Report',
+    who: 'You spotted something wrong. A broken page, outdated info, a wrong number.',
+    action: 'Open a bug report',
+    href: `${REPO}/issues/new?template=bug_report.md`,
+    alt: { action: 'or say it in Discord', href: '/discord' },
+    note: 'GitHub keeps a record others can pick up. Discord works if you have no account.',
+  },
+  {
+    id: 'ideas',
+    commitment: 2,
+    mode: 'ideas',
+    modeLabel: 'Ideas',
+    who: 'You have an idea for something BetterGov should build.',
+    action: 'Share an idea',
+    href: '/ideas',
+    alt: { action: 'or talk it through in Discord', href: '/discord' },
+    note: 'The form files it as a GitHub issue. Discord is better for half-formed ideas.',
+  },
+  {
+    id: 'data',
+    commitment: 3,
+    mode: 'code',
+    modeLabel: 'Data',
+    who: 'You can fix or add government data: directories, hotlines, services.',
+    action: 'Browse the data files',
+    href: `${REPO}/tree/main/src/data`,
+    note: 'Plain JSON. Edit on GitHub without cloning anything.',
+  },
+  {
+    id: 'code',
+    commitment: 4,
+    mode: 'code',
+    modeLabel: 'Code',
+    who: 'You write code and want a scoped first task.',
+    action: 'Find a good first issue',
+    href: `${REPO}/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22`,
+    note: 'Read CONTRIBUTING.md first. It covers setup and the PR flow.',
+  },
+  {
+    id: 'review',
+    commitment: 4,
+    mode: 'review',
+    modeLabel: 'Review',
+    who: 'You can read code and give feedback, often more useful than writing more.',
+    action: 'Review an open pull request',
+    href: `${REPO}/pulls`,
+    note: 'Reviews are the scarcest thing in most open-source projects.',
+  },
+  {
+    id: 'sibling',
+    commitment: 4,
+    mode: 'project',
+    modeLabel: 'Other projects',
+    who: 'This repo is one of many. Another BetterGov project may fit you better.',
+    action: 'Browse all BetterGov projects',
+    href: '/projects',
+    note: 'Each project has its own repository and its own open issues.',
+  },
+  {
+    id: 'register',
+    commitment: 5,
+    mode: 'project',
+    modeLabel: 'Your project',
+    who: 'You are building your own civic tech project and want it listed here.',
+    action: 'Ask about listing your project',
+    // Routes to a human because the registry submission path is undocumented.
+    href: '/discord',
+    alt: {
+      action: 'or email the volunteers',
+      href: 'mailto:volunteers@bettergov.ph',
+    },
+    note: 'Community projects are listed alongside the official ones.',
+  },
+];
+
+export interface Intro {
+  eyebrow: string;
+  heading: string;
+  standfirst: string;
+}
+
+export const INTRO: Intro = {
+  eyebrow: 'Ways to help',
+  heading: 'Every way in, easiest first',
+  standfirst:
+    'BetterGov.ph is a volunteer-led, open-source civic tech project. Pick the first one that sounds like you. Nothing here needs permission to start.',
+};

--- a/src/pages/contribute/index.tsx
+++ b/src/pages/contribute/index.tsx
@@ -1,0 +1,38 @@
+import { FC } from 'react';
+import SEO from '../../components/SEO';
+import { ContributeHero } from './ContributeHero';
+import { ContributeRouter } from './ContributeRouter';
+
+// Sits beside /join-us rather than replacing it: /join-us introduces the
+// project, /contribute routes someone already interested to a first task.
+const Contribute: FC = () => (
+  <div className='min-h-screen bg-gray-50'>
+    {/* Title and description come from src/data/seo-metadata.json */}
+    <SEO
+      keywords={[
+        'contribute',
+        'volunteer',
+        'open source',
+        'civic tech',
+        'bettergov',
+        'philippines',
+      ]}
+      breadcrumbs={[
+        { name: 'Home', url: '/' },
+        { name: 'Contribute', url: '/contribute' },
+      ]}
+    />
+
+    <ContributeHero />
+
+    <section
+      id='ways-to-help'
+      aria-labelledby='ways-to-help-heading'
+      className='py-12 md:py-16 scroll-mt-4'
+    >
+      <ContributeRouter />
+    </section>
+  </div>
+);
+
+export default Contribute;

--- a/src/pages/sitemap/index.tsx
+++ b/src/pages/sitemap/index.tsx
@@ -31,6 +31,11 @@ const SitemapPage: FC = () => {
         { title: 'Home', url: '/', description: 'Main landing page' },
         { title: 'About', url: '/about', description: 'About BetterGov.ph' },
         {
+          title: 'Contribute',
+          url: '/contribute',
+          description: 'Every way to help, ordered from easiest to hardest',
+        },
+        {
           title: 'Accessibility',
           url: '/accessibility',
           description: 'Accessibility statement and features',


### PR DESCRIPTION
## What type of PR is this?

- [x] Bug
- [ ] Change
- [ ] Feature
- [ ] Miscellaneous

## What you changed and why?

Updated the TIN registration service URL from the ORUS root route to the documented /home route, which is the route users need to reach the service.

## Please specify which issue this PR Resolves

Closes #687

## Checklist

- [x] I have performed a self-review of my own code.
- [x] These changes are ready for review.
- [x] This contribution was assisted by an AI agent (GPT-5 in Codex).

## Notes

The JSON file remains valid after the change.