### PR TITLE
docs: align PR instructions with pull request template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -379,9 +379,13 @@ We use Pull Requests (PRs) to review and merge changes. Follow these steps when 
 **Open a Pull Request to the main repository:**
 
 - Target the main branch (or the branch specified by maintainers).
-- Provide a clear title and detailed description of your changes.
-- Reference any related issues (e.g., Closes #12).
-- **AI-Assisted Work Disclosure:** If you used AI tools to help generate or significantly modify code in your PR, please disclose this in the PR description. This helps maintainers conduct a more thorough review.
+- Provide a clear title for your changes.
+- **Follow the Pull Request Template:** Your PR description must follow the structure provided in the `.github/pull_request_template.md` template. Please ensure you fill out all required sections:
+  - **PR Type:** Select the appropriate category (Bug, Change, Feature, Miscellaneous).
+  - **Description:** Provide a detailed summary of what you changed and why under the "What you changed and why?" heading.
+  - **Issue Reference:** Specify any related issues under "Please specify which issue this PR Resolves" (e.g., `Closes #12`).
+  - **Checklist:** Complete the pre-submission checklist, including self-review and draft status.
+  - **AI-Assisted Work Disclosure:** If you used AI tools to help generate or significantly modify code, you must check the AI assistance box in the checklist **AND** disclose the specific tool used under the "AI Disclosure" heading at the bottom of the template.
 
 **Wait for review:**
 


### PR DESCRIPTION
# What type of PR is this?

- [ ] Bug
- [ ] Change
- [ ] Feature
- [x] Miscellaneous

---

## What you changed and why?

- Updated the `CONTRIBUTING.md` pull request instructions so they match the repository's current `.github/pull_request_template.md` structure.
- The guide now tells contributors to complete the PR type, description, issue reference, checklist, and AI disclosure fields instead of only giving generic PR-description guidance.
- This recreates the documentation-only change from #707 on a fresh branch based on current upstream `main`, as requested in the maintainer review. No changes from #706 are included.

---

## Please specify which issue this PR Resolves (if applicable)

N/A — follow-up to the maintainer request on #707.

---

## Checklist

- [x] I have performed a self-review of my own code.
- [x] These changes are now ready for review, or will be marked as draft.
- [x] This contribution was assisted by an AI agent. (if yes, please specify what agent is used under notes)

---

## Notes

- Diff is limited to `CONTRIBUTING.md`: 7 additions, 3 deletions.
- The branch starts from current upstream `main` (`0149c9e1d744c6a03acebea673e5b3d3e45116ed`).
- AI assistance: OpenAI ChatGPT was used to verify current repository instructions, prepare the clean branch, and submit this revision.

---

## AI Disclosure

- This contribution was developed with the assistance of an AI coding tool: "OpenAI GPT 5.6 Sol Very High".
