### PR TITLE
fix(ci): install Playwright from lockfile to resolve zizmor adhoc-packages finding

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -121,8 +121,8 @@ jobs:
         with:
           node-version-file: '.nvmrc'
 
-      - name: Install Playwright dependencies only
-        run: npm install @playwright/test
+      - name: Install dependencies
+        run: npm ci
 
       - name: Download all blob reports
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1


### PR DESCRIPTION
## What this does

The `merge_reports` job in `build-test.yml` installed Playwright ad hoc:

```yaml
- name: Install Playwright dependencies only
  run: npm install @playwright/test
```

zizmor flags this as an `adhoc-packages` finding (1 unsuppressed low), which fails the security check, per #746.

`@playwright/test` is already a declared `devDependency` (`^1.55.0`) and is in `package-lock.json`, so this replaces the ad-hoc install with `npm ci`, matching how the other jobs already install dependencies. The Playwright version used to merge reports is now pinned to the lockfile instead of floating.

## Verification

Ran zizmor locally against `build-test.yml`:

- Before: `7 findings (6 suppressed): 0 informational, 1 low, 0 medium, 0 high` (the `adhoc-packages` finding)
- After: `No findings to report. Good job! (6 suppressed)`

The 6 pre-existing suppressions are unchanged.

## Tasks from the issue

- [x] `@playwright/test` in `devDependencies` (already present)
- [x] `package-lock.json` already contains it
- [x] Removed `npm install @playwright/test` from `build-test.yml`
- [x] Job installs dependencies with `npm ci`
- [x] Verified the zizmor `adhoc-packages` finding is resolved

Closes #746

---

**AI-Assisted Work Disclosure:** This change was prepared with AI assistance (Claude Code). The one-line workflow edit and the local zizmor verification were reviewed by me before submitting.
